### PR TITLE
feat: enable silent printing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, ipcMain } from 'electron'
+import { join } from 'path'
 import { getMainScreen } from './utils/screen'
 import getURL from './utils/getURL'
+import registerPrintHandler from './ipc/print'
 
 // Allow use of `speechSynthesis` API.
 app.commandLine.appendSwitch('enable-speech-dispatcher')
@@ -18,13 +20,19 @@ async function createWindow(): Promise<void> {
     height: mainScreen?.height ?? 600,
     kiosk: true,
     frame: false,
+    webPreferences: {
+      preload: join(__dirname, 'preload.js'),
+    },
   })
 
-  // and load the index.html of the app.
+  // and load the initial page.
   mainWindow.loadURL(getURL().href)
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools()
+
+  // Register IPC handlers.
+  registerPrintHandler(ipcMain)
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/src/ipc/print.ts
+++ b/src/ipc/print.ts
@@ -1,0 +1,33 @@
+import { IpcMainInvokeEvent, WebContents, PrinterInfo, IpcMain } from 'electron'
+
+export function getDefaultPrinter(webContents: WebContents): PrinterInfo {
+  const printers = webContents.getPrinters()
+  return printers.find(printer => printer.isDefault) ?? printers[0]
+}
+
+export const channel = 'print'
+
+/**
+ * Enable directly printing without a prompt.
+ */
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(
+    channel,
+    (event: IpcMainInvokeEvent) =>
+      new Promise((resolve, reject) =>
+        event.sender.print(
+          {
+            silent: true,
+            deviceName: getDefaultPrinter(event.sender).name,
+          },
+          (success, failureReason) => {
+            if (success) {
+              resolve()
+            } else {
+              reject(failureReason)
+            }
+          },
+        ),
+      ),
+  )
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,10 @@
+import { ipcRenderer } from 'electron'
+import { channel as printChannel } from './ipc/print'
+
+class Kiosk {
+  public async print(): Promise<void> {
+    await ipcRenderer.invoke(printChannel)
+  }
+}
+
+;(window as typeof window & { kiosk: Kiosk }).kiosk = new Kiosk()


### PR DESCRIPTION
This commit adds silent printing by calling `kiosk.print()` from within the hosted webpage. The global `kiosk` is added by the `preload.js` script and will expose more features in the future.