### PR TITLE
feat: add `kiosk.getBatteryInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Generic kiosk-mode browser.
 1. Install it with `sudo dpkg -i kiosk-browser_*_amd64.deb` (note wildcard).
 1. Run with the URL you want to visit as a CLI argument (e.g. `kiosk-browser http://example.com/`) or with an environment variable (e.g. `KIOSK_BROWSER_URL=http://example.com/ kiosk-browser`).
 
+## Kiosk Page API
+
+Web pages loaded by `kiosk-browser` have an extra API accessible via the global `kiosk` object.
+
+`kiosk.`**`getBatteryInfo`**`(): Promise<{ level: number, discharging: boolean }>`
+
+Gets an object describing the current state of the battery, including level and discharging status.
+
+`kiosk.`**`print`**`(): Promise<void>`
+
+Prints the current page using the default printer. This is different from `window.print` in that it is silent; there are no dialogs or prompts. Resolves if printing succeeds, rejects otherwise.
+
 ## License
 
 GPL-3.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { getMainScreen } from './utils/screen'
 import getURL from './utils/getURL'
 import registerPrintHandler from './ipc/print'
+import registerGetBatteryInfoHandler from './ipc/get-battery-info'
 
 // Allow use of `speechSynthesis` API.
 app.commandLine.appendSwitch('enable-speech-dispatcher')
@@ -33,6 +34,7 @@ async function createWindow(): Promise<void> {
 
   // Register IPC handlers.
   registerPrintHandler(ipcMain)
+  registerGetBatteryInfoHandler(ipcMain)
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/src/ipc/get-battery-info.ts
+++ b/src/ipc/get-battery-info.ts
@@ -1,0 +1,49 @@
+import { IpcMain } from 'electron'
+import * as fs from 'fs'
+import { promisify } from 'util'
+
+const readFile = promisify(fs.readFile)
+
+enum BatteryStatus {
+  Charging = 'Charging',
+  Discharging = 'Discharging',
+  NotCharging = 'Not charging',
+  Full = 'Full',
+  Unknown = 'Unknown',
+}
+
+export interface BatteryInfo {
+  level: number
+  discharging: boolean
+}
+
+export const channel = 'get-battery-info'
+
+/**
+ * Get battery info for the main system battery.
+ */
+export async function getBatteryInfo(): Promise<BatteryInfo> {
+  const batteryInfoText = await readFile(
+    '/sys/class/power_supply/BAT0/uevent',
+    'utf8',
+  )
+
+  const batteryInfo = batteryInfoText.split('\n').reduce((data, line) => {
+    const [key, value] = line.split('=')
+    data.set(key, value)
+    return data
+  }, new Map<string, string>())
+
+  const energyNow = batteryInfo.get('POWER_SUPPLY_ENERGY_NOW')
+  const energyFull = batteryInfo.get('POWER_SUPPLY_ENERGY_FULL')
+  const status = batteryInfo.get('POWER_SUPPLY_STATUS') as BatteryStatus
+  const level = Number(energyNow) / Number(energyFull)
+  const discharging =
+    status !== BatteryStatus.Full && status !== BatteryStatus.Charging
+
+  return { level, discharging }
+}
+
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(channel, () => getBatteryInfo())
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,9 +1,17 @@
 import { ipcRenderer } from 'electron'
 import { channel as printChannel } from './ipc/print'
+import {
+  BatteryInfo,
+  channel as getBatteryInfoChannel,
+} from './ipc/get-battery-info'
 
 class Kiosk {
   public async print(): Promise<void> {
     await ipcRenderer.invoke(printChannel)
+  }
+
+  public async getBatteryInfo(): Promise<BatteryInfo> {
+    return ipcRenderer.invoke(getBatteryInfoChannel)
   }
 }
 


### PR DESCRIPTION
This enables hosted web pages to get the battery status without having to use the deprecated Battery Status API: https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API.