### PR TITLE
feat: add `kiosk.getPrinterInfo` API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { getMainScreen } from './utils/screen'
 import getURL from './utils/getURL'
 import registerPrintHandler from './ipc/print'
 import registerGetBatteryInfoHandler from './ipc/get-battery-info'
+import registerGetPrinterInfoHandler from './ipc/get-printer-info'
 
 // Allow use of `speechSynthesis` API.
 app.commandLine.appendSwitch('enable-speech-dispatcher')
@@ -35,6 +36,7 @@ async function createWindow(): Promise<void> {
   // Register IPC handlers.
   registerPrintHandler(ipcMain)
   registerGetBatteryInfoHandler(ipcMain)
+  registerGetPrinterInfoHandler(ipcMain)
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/src/ipc/get-printer-info.ts
+++ b/src/ipc/get-printer-info.ts
@@ -1,0 +1,72 @@
+import { IpcMainInvokeEvent, IpcMain } from 'electron'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const exec = promisify(execFile)
+
+export const channel = 'get-printer-info'
+
+export interface PrinterInfo extends Electron.PrinterInfo {
+  connected: boolean
+}
+
+/**
+ * Gets the URIs of any connected printers matching the given schemes.
+ */
+export async function getConnectedDeviceURIs(
+  schemes?: Set<string>,
+): Promise<Set<string>> {
+  const lpinfoArgs: string[] = []
+
+  if (schemes?.size) {
+    lpinfoArgs.push(
+      '--include-schemes',
+      Array.from(schemes).join(','), // e.g. usb
+    )
+  }
+
+  // Show available devices with `-v` vs available drivers with `-m`.
+  lpinfoArgs.push('-v')
+
+  const { stdout } = await exec('lpinfo', lpinfoArgs)
+
+  return new Set(stdout.split('\n').map(line => line.split(/\s+/, 2)[1]))
+}
+
+/**
+ * Gets the printer schemes from the given printers, for example `usb`.
+ */
+export function printerSchemes(printers: Electron.PrinterInfo[]): Set<string> {
+  const uris = printers
+    .map(printer => printer.options?.['device-uri'])
+    .filter(Boolean) as string[]
+  return new Set(uris.map(uri => new URL(uri).protocol.slice(0, -1)))
+}
+
+/**
+ * Get information about all known printers, including connection status.
+ */
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(
+    channel,
+    async (event: IpcMainInvokeEvent): Promise<PrinterInfo[]> => {
+      const results: PrinterInfo[] = []
+      const printers = event.sender.getPrinters()
+      const connectedDeviceURIs = await getConnectedDeviceURIs(
+        printerSchemes(printers),
+      )
+
+      for (const printer of printers) {
+        const deviceURI = printer.options?.['device-uri']
+        const connected = deviceURI ? connectedDeviceURIs.has(deviceURI) : false
+
+        results.push({
+          ...printer,
+          connected,
+        })
+      }
+
+      return results
+    },
+  )
+}

--- a/src/ipc/print.ts
+++ b/src/ipc/print.ts
@@ -1,9 +1,5 @@
-import { IpcMainInvokeEvent, WebContents, PrinterInfo, IpcMain } from 'electron'
-
-export function getDefaultPrinter(webContents: WebContents): PrinterInfo {
-  const printers = webContents.getPrinters()
-  return printers.find(printer => printer.isDefault) ?? printers[0]
-}
+import { IpcMainInvokeEvent, IpcMain } from 'electron'
+import getPreferredPrinter from '../utils/getPreferredPrinter'
 
 export const channel = 'print'
 
@@ -13,12 +9,15 @@ export const channel = 'print'
 export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(
     channel,
-    (event: IpcMainInvokeEvent) =>
+    (
+      event: IpcMainInvokeEvent,
+      deviceName = getPreferredPrinter(event.sender)?.name,
+    ) =>
       new Promise((resolve, reject) =>
         event.sender.print(
           {
             silent: true,
-            deviceName: getDefaultPrinter(event.sender).name,
+            deviceName,
           },
           (success, failureReason) => {
             if (success) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,14 +4,22 @@ import {
   BatteryInfo,
   channel as getBatteryInfoChannel,
 } from './ipc/get-battery-info'
+import {
+  PrinterInfo,
+  channel as getPrinterInfoChannel,
+} from './ipc/get-printer-info'
 
 class Kiosk {
-  public async print(): Promise<void> {
-    await ipcRenderer.invoke(printChannel)
+  public async print(deviceName?: string): Promise<void> {
+    await ipcRenderer.invoke(printChannel, deviceName)
   }
 
   public async getBatteryInfo(): Promise<BatteryInfo> {
     return ipcRenderer.invoke(getBatteryInfoChannel)
+  }
+
+  public async getPrinterInfo(): Promise<PrinterInfo[]> {
+    return ipcRenderer.invoke(getPrinterInfoChannel)
   }
 }
 

--- a/src/utils/getPreferredPrinter.ts
+++ b/src/utils/getPreferredPrinter.ts
@@ -1,0 +1,11 @@
+import { WebContents, PrinterInfo } from 'electron'
+
+/**
+ * Gets either the default printer or the first available printer.
+ */
+export default function getPreferredPrinter(
+  webContents: WebContents,
+): PrinterInfo | undefined {
+  const printers = webContents.getPrinters()
+  return printers.find(printer => printer.isDefault) ?? printers[0]
+}

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1,0 +1,8 @@
+declare namespace Electron {
+  interface PrinterInfo {
+    /**
+     * Add printer options such as `printer-is-accepting-jobs`.
+     */
+    options?: { [key: string]: string }
+  }
+}


### PR DESCRIPTION
This method allows callers to determine which printers are connected and which is the default. This commit also modifies `kiosk.print` to accept a device name to print to.