### PR TITLE
test: ignore 'out' directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   clearMocks: true,
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
-  testPathIgnorePatterns: ['/dist/'],
+  testPathIgnorePatterns: ['/dist/', '/out/'],
   coverageThreshold: {
     global: {
       statements: 100,


### PR DESCRIPTION
Otherwise jest tries to look in there and gets confused.