### PR TITLE
refactor: extract `Resource` from assertions

### DIFF
--- a/__mocks__/usb-detection.ts
+++ b/__mocks__/usb-detection.ts
@@ -1,0 +1,13 @@
+const startMonitoring = jest.fn()
+const stopMonitoring = jest.fn()
+const find = jest.fn()
+const on = jest.fn()
+const off = jest.fn()
+
+export default {
+  startMonitoring,
+  stopMonitoring,
+  find,
+  on,
+  off,
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   clearMocks: true,
+  resetModules: true,
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
   testPathIgnorePatterns: ['/dist/', '/out/'],
   coverageThreshold: {

--- a/src/ipc/get-device-list.ts
+++ b/src/ipc/get-device-list.ts
@@ -1,5 +1,5 @@
 import { IpcMain } from 'electron'
-import { assertMonitoring, getDeviceList } from '../utils/usb'
+import { getDeviceList, usbResource } from '../utils/usb'
 
 export const channel = 'get-device-list'
 
@@ -8,10 +8,10 @@ export const channel = 'get-device-list'
  */
 export default function register(ipcMain: IpcMain): () => void {
   // Always monitor devices, otherwise `getDeviceList` will be cached and stale.
-  const monitoringAssertion = assertMonitoring()
+  const usbMonitor = usbResource.retain()
 
   ipcMain.handle(channel, () => getDeviceList())
 
-  // Cleanup releases USB monitoring assertion.
-  return () => monitoringAssertion.release()
+  // Cleanup releases USB monitoring.
+  return () => usbMonitor.release()
 }

--- a/src/ipc/manage-device-subscription.ts
+++ b/src/ipc/manage-device-subscription.ts
@@ -1,5 +1,5 @@
 import { IpcMain, IpcMainInvokeEvent, WebContents } from 'electron'
-import { assertMonitoring, onDeviceChange, Device } from '../utils/usb'
+import { onDeviceChange, Device, usbResource } from '../utils/usb'
 import { Listener } from '../utils/Listeners'
 
 export const channel = 'manage-device-subscription'
@@ -17,7 +17,7 @@ export default function register(ipcMain: IpcMain): (() => void) | undefined {
   const subscribers = new Map<WebContents, Listener<[ChangeType, Device]>>()
 
   // Always monitor devices.
-  const monitoringAssertion = assertMonitoring()
+  const usbMonitor = usbResource.retain()
 
   ipcMain.handle(channel, (event: IpcMainInvokeEvent, subscribe: boolean) => {
     const webContents = event.sender
@@ -39,5 +39,5 @@ export default function register(ipcMain: IpcMain): (() => void) | undefined {
     }
   })
 
-  return () => monitoringAssertion.release()
+  return () => usbMonitor.release()
 }

--- a/src/utils/resources.test.ts
+++ b/src/utils/resources.test.ts
@@ -1,0 +1,36 @@
+import { Resource } from './resources'
+
+test('resources are not retained by default', () => {
+  expect(new Resource().isRetained()).toBe(false)
+})
+
+test('resources are retained once retain is called', () => {
+  const resource = new Resource()
+  resource.retain()
+  expect(resource.isRetained()).toBe(true)
+})
+
+test('retained resources can be individually released', () => {
+  const resource = new Resource()
+  resource.retain().release()
+  expect(resource.isRetained()).toBe(false)
+})
+
+test('retained resources can be released all at once', () => {
+  const resource = new Resource()
+  resource.retain()
+  resource.retain()
+  resource.retain()
+  resource.releaseAll()
+  expect(resource.isRetained()).toBe(false)
+})
+
+test('retains cannot be released multiple times', () => {
+  const resource = new Resource()
+  const retain = resource.retain()
+
+  // once works
+  retain.release()
+  // twice doesn't
+  expect(() => retain.release()).toThrowError(/already been released/)
+})

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -1,0 +1,56 @@
+/**
+ * Represents a retain of a resource.
+ */
+export class Retain {
+  public constructor(private resource: Resource) {}
+
+  /**
+   * Releases this retain.
+   */
+  public release(): void {
+    this.resource.release(this)
+  }
+}
+
+/**
+ * Represents a shared resource that consumers can retain an interest in.
+ */
+export class Resource {
+  private retains = new Set<Retain>()
+
+  /**
+   * Retains a resource until its value is released.
+   */
+  public retain(): Retain {
+    const retention = new Retain(this)
+    this.retains.add(retention)
+    return retention
+  }
+
+  /**
+   * Releases a previously retained value.
+   */
+  public release(retain: Retain): void {
+    const hadRetain = this.retains.delete(retain)
+
+    if (!hadRetain) {
+      throw new Error(
+        'given retain is not associated with this resource or has already been released',
+      )
+    }
+  }
+
+  /**
+   * Releases all retains held by this resource.
+   */
+  public releaseAll(): void {
+    this.retains.clear()
+  }
+
+  /**
+   * Determines whether this resource has any outstanding retains.
+   */
+  public isRetained(): boolean {
+    return this.retains.size > 0
+  }
+}

--- a/src/utils/usb.test.ts
+++ b/src/utils/usb.test.ts
@@ -1,48 +1,26 @@
-import { isMonitoring, assertMonitoring, clearAssertions } from './usb'
+import { usbResource } from './usb'
 import usbDetection from 'usb-detection'
-import mockOf from '../../test/mockOf'
-
-jest.mock('usb-detection', () => ({
-  __esModule: true,
-  default: {
-    find: jest.fn(),
-    startMonitoring: jest.fn(),
-    stopMonitoring: jest.fn(),
-    on: jest.fn(),
-    off: jest.fn(),
-  },
-}))
-
-beforeEach(() => {
-  mockOf(usbDetection.find).mockReset()
-  mockOf(usbDetection.startMonitoring).mockReset()
-  mockOf(usbDetection.stopMonitoring).mockReset()
-  mockOf(usbDetection.on).mockReset()
-  mockOf(usbDetection.off).mockReset()
-
-  clearAssertions()
-})
 
 test('monitoring is off by default', () => {
-  expect(isMonitoring()).toBe(false)
+  expect(usbResource.isRetained()).toBe(false)
 })
 
-test('monitoring is on once an assertion is made', () => {
-  assertMonitoring()
+test('monitoring is on once the USB resource has been retained', () => {
+  usbResource.retain()
   expect(usbDetection.startMonitoring).toHaveBeenCalledTimes(1)
-  expect(isMonitoring()).toBe(true)
+  expect(usbResource.isRetained()).toBe(true)
 })
 
-test('monitoring is off once an assertion is released', () => {
-  const assertion = assertMonitoring()
-  expect(isMonitoring()).toBe(true)
-  assertion.release()
-  expect(isMonitoring()).toBe(false)
+test('monitoring is off once a retain is released', () => {
+  const retain = usbResource.retain()
+  expect(usbResource.isRetained()).toBe(true)
+  retain.release()
+  expect(usbResource.isRetained()).toBe(false)
   expect(usbDetection.stopMonitoring).toHaveBeenCalledTimes(1)
 })
 
 test('startMonitoring is only called once', () => {
-  assertMonitoring()
-  assertMonitoring()
+  usbResource.retain()
+  usbResource.retain()
   expect(usbDetection.startMonitoring).toHaveBeenCalledTimes(1)
 })

--- a/src/utils/usb.ts
+++ b/src/utils/usb.ts
@@ -1,40 +1,50 @@
 import usbDetection, { Device } from 'usb-detection'
 import Listeners from './Listeners'
 import { ChangeType } from '../ipc/manage-device-subscription'
+import { Resource, Retain } from './resources'
 
-const assertions = new Set<object>()
+/**
+ * Centralizes access to the USB monitoring resource to ensure monitoring is
+ * started and stopped appropriately.
+ */
+class USBResource extends Resource {
+  /**
+   * Retains access to USB monitoring until the result is released.
+   */
+  public retain(): Retain {
+    if (!this.isRetained()) {
+      usbDetection.startMonitoring()
+    }
 
-export interface Assertion {
-  release(): void
-}
-
-export function clearAssertions(): void {
-  assertions.clear()
-}
-
-export function isMonitoring(): boolean {
-  return assertions.size > 0
-}
-
-export function assertMonitoring(): Assertion {
-  if (!isMonitoring()) {
-    usbDetection.startMonitoring()
+    return super.retain()
   }
 
-  const token = {}
+  /**
+   * Releases the given retain value.
+   */
+  public release(retain: Retain): void {
+    super.release(retain)
 
-  assertions.add(token)
+    if (!this.isRetained()) {
+      usbDetection.stopMonitoring()
+    }
+  }
 
-  return {
-    release() {
-      assertions.delete(token)
-
-      if (!isMonitoring()) {
-        usbDetection.stopMonitoring()
-      }
-    },
+  /**
+   * Releases all existing retain values.
+   */
+  public releaseAll(): void {
+    if (this.isRetained()) {
+      super.releaseAll()
+      usbDetection.stopMonitoring()
+    }
   }
 }
+
+/**
+ * Singleton instance for managing the USB monitoring resource.
+ */
+export const usbResource = new USBResource()
 
 export async function getDeviceList(): Promise<Device[]> {
   return await usbDetection.find()

--- a/test/fakeDevice.ts
+++ b/test/fakeDevice.ts
@@ -1,0 +1,14 @@
+import { Device } from 'usb-detection'
+
+export default function fakeDevice(props: Partial<Device> = {}): Device {
+  return {
+    deviceName: 'fake device',
+    deviceAddress: 0,
+    locationId: 0,
+    manufacturer: 'Acme Inc.',
+    productId: 0,
+    serialNumber: '12345',
+    vendorId: 0,
+    ...props,
+  }
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,5 @@
+import { usbResource } from '../src/utils/usb'
+
+afterEach(() => {
+  usbResource.releaseAll()
+})


### PR DESCRIPTION
This will be used for any future resource monitoring, such as for power.