### PR TITLE
feat: trigger change events for initial devices

### DIFF
--- a/__mocks__/usb-detection.ts
+++ b/__mocks__/usb-detection.ts
@@ -1,0 +1,23 @@
+import mockOf from '../test/mockOf'
+
+const find = jest.fn().mockResolvedValue([])
+const startMonitoring = jest.fn()
+const stopMonitoring = jest.fn()
+const on = jest.fn()
+const off = jest.fn()
+
+beforeEach(() => {
+  mockOf(find).mockClear()
+  mockOf(startMonitoring).mockClear()
+  mockOf(stopMonitoring).mockClear()
+  mockOf(on).mockClear()
+  mockOf(off).mockClear()
+})
+
+export default {
+  find,
+  startMonitoring,
+  stopMonitoring,
+  on,
+  off,
+}

--- a/src/ipc/get-device-list.ts
+++ b/src/ipc/get-device-list.ts
@@ -1,5 +1,5 @@
 import { IpcMain } from 'electron'
-import { assertMonitoring, getDeviceList } from '../utils/usb'
+import { getDeviceList, onDeviceChange } from '../utils/usb'
 
 export const channel = 'get-device-list'
 
@@ -8,10 +8,10 @@ export const channel = 'get-device-list'
  */
 export default function register(ipcMain: IpcMain): () => void {
   // Always monitor devices, otherwise `getDeviceList` will be cached and stale.
-  const monitoringAssertion = assertMonitoring()
+  const listener = onDeviceChange.add(() => {})
 
   ipcMain.handle(channel, () => getDeviceList())
 
   // Cleanup releases USB monitoring assertion.
-  return () => monitoringAssertion.release()
+  return () => listener.remove()
 }

--- a/src/utils/DeviceChangeListeners.ts
+++ b/src/utils/DeviceChangeListeners.ts
@@ -21,7 +21,10 @@ export default class DeviceChangeListeners extends Listeners<
    * Called when a listener is added, allows us to notice when we have our first
    * listener.
    */
-  protected listenerAdded(count: number): void {
+  protected listenerAdded(
+    callback: (changeType: ChangeType, device: Device) => void,
+    count: number,
+  ): void {
     if (count === 1) {
       this.startMonitoringDevices()
     }
@@ -31,7 +34,10 @@ export default class DeviceChangeListeners extends Listeners<
    * Called when a listener is removed, allows us to notice when we have no more
    * listeners.
    */
-  protected listenerRemoved(count: number): void {
+  protected listenerRemoved(
+    callback: (changeType: ChangeType, device: Device) => void,
+    count: number,
+  ): void {
     if (count === 0) {
       this.stopMonitoringDevices()
     }
@@ -52,15 +58,15 @@ export default class DeviceChangeListeners extends Listeners<
    * Starts monitoring connected device add/remove events.
    */
   private startMonitoringDevices(): void {
-    this.ipcRenderer.invoke(manageDeviceSubscriptionChannel, true)
     this.ipcRenderer.on(deviceChangeChannel, this.onDeviceChangeIpcCallback)
+    this.ipcRenderer.invoke(manageDeviceSubscriptionChannel, true)
   }
 
   /**
    * Stops monitoring connected device add/remove events.
    */
   private stopMonitoringDevices(): void {
-    this.ipcRenderer.invoke(manageDeviceSubscriptionChannel, false)
     this.ipcRenderer.off(deviceChangeChannel, this.onDeviceChangeIpcCallback)
+    this.ipcRenderer.invoke(manageDeviceSubscriptionChannel, false)
   }
 }

--- a/src/utils/Listeners.test.ts
+++ b/src/utils/Listeners.test.ts
@@ -1,4 +1,4 @@
-import Listeners from './Listeners'
+import Listeners, { Listener } from './Listeners'
 
 class TestListeners extends Listeners {}
 
@@ -46,11 +46,11 @@ test('calls a hook on adding or removing a callback', () => {
   const calls = new Array<{ add: number } | { remove: number }>()
 
   class WithHooks extends TestListeners {
-    public listenerAdded(count: number): void {
+    public listenerAdded(callback: () => void, count: number): void {
       calls.push({ add: count })
     }
 
-    public listenerRemoved(count: number): void {
+    public listenerRemoved(callback: () => void, count: number): void {
       calls.push({ remove: count })
     }
   }
@@ -100,4 +100,17 @@ test('calls all callbacks, even if an earlier one fails', () => {
 
   expect(callbacks[0]).toHaveBeenCalledTimes(1)
   expect(callbacks[1]).toHaveBeenCalledTimes(1)
+})
+
+test('pausing callback interaction', () => {
+  const listeners = new TestListeners()
+  const callback = jest.fn()
+
+  listeners.pause()
+  listeners.add(callback)
+  listeners.trigger()
+
+  expect(callback).not.toHaveBeenCalled()
+  listeners.resume()
+  expect(callback).toHaveBeenCalledTimes(1)
 })

--- a/src/utils/usb.test.ts
+++ b/src/utils/usb.test.ts
@@ -1,48 +1,86 @@
-import { isMonitoring, assertMonitoring, clearAssertions } from './usb'
+import { onDeviceChange } from './usb'
 import usbDetection from 'usb-detection'
 import mockOf from '../../test/mockOf'
+import fakeDevice from '../../test/fakeDevice'
+import { ChangeType } from '../ipc/manage-device-subscription'
 
-jest.mock('usb-detection', () => ({
-  __esModule: true,
-  default: {
-    find: jest.fn(),
-    startMonitoring: jest.fn(),
-    stopMonitoring: jest.fn(),
-    on: jest.fn(),
-    off: jest.fn(),
-  },
-}))
-
-beforeEach(() => {
-  mockOf(usbDetection.find).mockReset()
-  mockOf(usbDetection.startMonitoring).mockReset()
-  mockOf(usbDetection.stopMonitoring).mockReset()
-  mockOf(usbDetection.on).mockReset()
-  mockOf(usbDetection.off).mockReset()
-
-  clearAssertions()
+afterEach(() => {
+  onDeviceChange.removeAll()
 })
 
 test('monitoring is off by default', () => {
-  expect(isMonitoring()).toBe(false)
+  expect(onDeviceChange.isPaused()).toBe(true)
 })
 
-test('monitoring is on once an assertion is made', () => {
-  assertMonitoring()
+test('monitoring is on once there is a listener', async () => {
+  onDeviceChange.add(jest.fn())
+  await onDeviceChange.waitForMonitoring()
   expect(usbDetection.startMonitoring).toHaveBeenCalledTimes(1)
-  expect(isMonitoring()).toBe(true)
+  expect(onDeviceChange.isPaused()).toBe(false)
 })
 
-test('monitoring is off once an assertion is released', () => {
-  const assertion = assertMonitoring()
-  expect(isMonitoring()).toBe(true)
-  assertion.release()
-  expect(isMonitoring()).toBe(false)
+test('monitoring is off once an assertion is released', async () => {
+  const listener = onDeviceChange.add(jest.fn())
+  await onDeviceChange.waitForMonitoring()
+  expect(onDeviceChange.isPaused()).toBe(false)
+  listener.remove()
+  await onDeviceChange.waitForMonitoring()
+  expect(onDeviceChange.isPaused()).toBe(true)
   expect(usbDetection.stopMonitoring).toHaveBeenCalledTimes(1)
 })
 
-test('startMonitoring is only called once', () => {
-  assertMonitoring()
-  assertMonitoring()
+test('startMonitoring is only called once', async () => {
+  onDeviceChange.add(jest.fn())
+  onDeviceChange.add(jest.fn())
+  await onDeviceChange.waitForMonitoring()
   expect(usbDetection.startMonitoring).toHaveBeenCalledTimes(1)
+})
+
+test('fires initial add callbacks with every existing device', async () => {
+  const callback = jest.fn()
+
+  mockOf(usbDetection.find).mockResolvedValueOnce([
+    fakeDevice({ deviceName: 'Device #1' }),
+    fakeDevice({ deviceName: 'Device #2' }),
+  ])
+  onDeviceChange.add(callback)
+  await onDeviceChange.waitForMonitoring()
+
+  expect(callback).toHaveBeenNthCalledWith(
+    1,
+    ChangeType.Add,
+    expect.objectContaining({ deviceName: 'Device #1' }),
+  )
+  expect(callback).toHaveBeenNthCalledWith(
+    2,
+    ChangeType.Add,
+    expect.objectContaining({ deviceName: 'Device #2' }),
+  )
+})
+
+test('does not fire initial add callbacks for removed devices', async () => {
+  const callback = jest.fn()
+  const devices = [
+    fakeDevice({ deviceName: 'Device #1' }),
+    fakeDevice({ deviceName: 'Device #2' }),
+  ]
+
+  mockOf(usbDetection.find).mockResolvedValueOnce(devices)
+
+  // Ensure device monitoring is on.
+  onDeviceChange.add(jest.fn())
+  await onDeviceChange.waitForMonitoring()
+
+  // Remove all devices.
+  const [, onDeviceRemoved] = mockOf(usbDetection.on).mock.calls.find(
+    call => call[0] === 'remove',
+  )!
+  for (const device of devices) {
+    onDeviceRemoved(device)
+  }
+
+  onDeviceChange.add(callback)
+  await onDeviceChange.waitForMonitoring()
+
+  expect(callback).not.toHaveBeenCalled()
 })

--- a/src/utils/usb.ts
+++ b/src/utils/usb.ts
@@ -2,52 +2,110 @@ import usbDetection, { Device } from 'usb-detection'
 import Listeners from './Listeners'
 import { ChangeType } from '../ipc/manage-device-subscription'
 
-const assertions = new Set<object>()
-
-export interface Assertion {
-  release(): void
-}
-
-export function clearAssertions(): void {
-  assertions.clear()
-}
-
-export function isMonitoring(): boolean {
-  return assertions.size > 0
-}
-
-export function assertMonitoring(): Assertion {
-  if (!isMonitoring()) {
-    usbDetection.startMonitoring()
-  }
-
-  const token = {}
-
-  assertions.add(token)
-
-  return {
-    release() {
-      assertions.delete(token)
-
-      if (!isMonitoring()) {
-        usbDetection.stopMonitoring()
-      }
-    },
-  }
+function devicesEqual(device: Device, other: Device): boolean {
+  return (
+    device.deviceAddress === other.deviceAddress &&
+    device.deviceName === other.deviceName &&
+    device.locationId === other.locationId &&
+    device.manufacturer === other.manufacturer &&
+    device.productId === other.productId &&
+    device.serialNumber === other.serialNumber &&
+    device.vendorId === other.vendorId
+  )
 }
 
 export async function getDeviceList(): Promise<Device[]> {
   return await usbDetection.find()
 }
 
-export const onDeviceChange = new Listeners<[ChangeType, Device]>()
+class USBDeviceListeners extends Listeners<[ChangeType, Device]> {
+  private devices = new Set<Device>()
+  private setupPromise?: Promise<void>
 
-usbDetection.on('add', device => {
-  onDeviceChange.trigger(ChangeType.Add, device)
-})
+  public constructor() {
+    super()
+    this.pause()
+  }
 
-usbDetection.on('remove', device => {
-  onDeviceChange.trigger(ChangeType.Remove, device)
-})
+  private onDeviceAdded = (added: Device) => {
+    this.devices.add(added)
+    this.trigger(ChangeType.Add, added)
+  }
+
+  private onDeviceRemoved = (removed: Device) => {
+    for (const existing of this.devices) {
+      if (devicesEqual(removed, existing)) {
+        this.devices.delete(existing)
+      }
+    }
+    this.trigger(ChangeType.Remove, removed)
+  }
+
+  public async waitForMonitoring(): Promise<void> {
+    await this.setupPromise
+  }
+
+  protected async listenerAdded(
+    callback: (changeType: ChangeType, device: Device) => void,
+    count: number,
+  ) {
+    if (count === 1) {
+      this.setupPromise = this.setup()
+    }
+
+    await this.setupPromise
+
+    for (const device of this.devices) {
+      try {
+        callback(ChangeType.Add, device)
+      } catch (error) {
+        console.error('event callback failed with error:', error)
+      }
+    }
+  }
+
+  private async setup(): Promise<void> {
+    // Start monitoring. This must be called before `find`.
+    usbDetection.startMonitoring()
+    usbDetection.on('add', this.onDeviceAdded)
+    usbDetection.on('remove', this.onDeviceRemoved)
+
+    // Cache the initial device list.
+    const devices = await usbDetection.find()
+    this.devices.clear()
+    for (const device of devices) {
+      this.devices.add(device)
+    }
+
+    // Begin dispatching events.
+    this.resume()
+  }
+
+  protected async listenerRemoved(
+    callback: (changeType: ChangeType, device: Device) => void,
+    count: number,
+  ) {
+    if (count === 0) {
+      await this.teardown()
+    }
+  }
+
+  private async teardown(): Promise<void> {
+    await this.setupPromise
+
+    // Stop dispatching events.
+    this.pause()
+
+    // Stop watching for changes.
+    usbDetection.stopMonitoring()
+    usbDetection.off('add', this.onDeviceAdded)
+    usbDetection.off('removed', this.onDeviceRemoved)
+
+    // Clear the cached device list.
+    this.devices.clear()
+  }
+}
+
+export const onDeviceChange = new USBDeviceListeners()
 
 export { Device }

--- a/test/fakeDevice.ts
+++ b/test/fakeDevice.ts
@@ -1,0 +1,14 @@
+import { Device } from '../src/utils/usb'
+
+export default function fakeDevice(props: Partial<Device> = {}): Device {
+  return {
+    deviceName: 'fake device',
+    deviceAddress: 0,
+    locationId: 0,
+    manufacturer: 'Acme Inc.',
+    productId: 0,
+    serialNumber: '12345',
+    vendorId: 0,
+    ...props,
+  }
+}


### PR DESCRIPTION
Rather than forcing consumers to separately get the device list and also listen for changes, fire change events as if all existing devices were added when the listening started.