### PR TITLE
ci: install dependencies with frozen lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,33 +5,33 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-   
+
     env:
       CI: true
 
     steps:
-    - uses: actions/checkout@v2
-      
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-        
-    - name: Install Native Dependencies
-      run: sudo apt-get install libudev-dev
+      - uses: actions/checkout@v2
 
-    - name: Get yarn cache
-      id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
 
-    - uses: actions/cache@v1
-      with:
-        path: ${{ steps.yarn-cache.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+      - name: Install Native Dependencies
+        run: sudo apt-get install libudev-dev
 
-    - name: Install Dependencies
-      run: yarn install
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - name: Run Tests
-      run: yarn test
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run Tests
+        run: yarn test


### PR DESCRIPTION
This should prevent `package.json` and `yarn.lock` from getting out of sync.