### PR TITLE
test: prevent `jest-haste-map` errors from showing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   clearMocks: true,
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
-  testPathIgnorePatterns: ['/dist/', '/out/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/out/'],
   coverageThreshold: {
     global: {
       statements: 100,


### PR DESCRIPTION
These were happening because jest didn't know to ignore `dist` and `out` directories when looking for _modules_, not _test_ files. This corrects the config so that jest ignores those directories.