### PR TITLE
refactor(security): print by piping to `lpr` instead of temp file

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "debug": "^4.1.1",
-    "tmp-promise": "^2.0.2",
     "usb-detection": "^4.7.0",
     "xrandr-parse": "^1.0.0"
   },
@@ -53,8 +52,8 @@
     "@electron-forge/maker-deb": "6.0.0-beta.47",
     "@types/debug": "^4.1.5",
     "@types/jest": "^24.9.0",
+    "@types/memorystream": "^0.3.0",
     "@types/node": "12",
-    "@types/tmp": "^0.1.0",
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
     "electron": "7.1.8",
@@ -64,6 +63,7 @@
     "husky": "^4.2.1",
     "jest": "^24.9.0",
     "lint-staged": "^10.0.7",
+    "memorystream": "^0.3.1",
     "prettier": "^1.19.1",
     "sort-package-json": "^1.39.1",
     "ts-jest": "^24.3.0",

--- a/src/ipc/print.test.ts
+++ b/src/ipc/print.test.ts
@@ -54,13 +54,11 @@ test('registers a handler to trigger a print', async () => {
     printBackground: true,
   })
 
-  expect(execMock).toHaveBeenCalledWith('lpr', [
-    '-P',
-    'mainprinter',
-    '-o',
-    'InputSlot=Tray3',
-    expect.any(String),
-  ])
+  expect(execMock).toHaveBeenCalledWith(
+    'lpr',
+    ['-P', 'mainprinter', '-o', 'InputSlot=Tray3'],
+    expect.anything(),
+  )
 })
 
 test('uses the preferred printer if none is provided', async () => {
@@ -95,11 +93,11 @@ test('uses the preferred printer if none is provided', async () => {
 
   expect(sender.printToPDF).toHaveBeenCalledWith({ printBackground: true })
 
-  expect(execMock).toHaveBeenCalledWith('lpr', [
-    '-P',
-    'main printer',
-    expect.any(String),
-  ])
+  expect(execMock).toHaveBeenCalledWith(
+    'lpr',
+    ['-P', 'main printer'],
+    expect.anything(),
+  )
 })
 
 test('propagates errors', async () => {

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,0 +1,134 @@
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process'
+import exec from './exec'
+import mockOf from '../../test/mockOf'
+import { EventEmitter } from 'events'
+import MemoryStream from 'memorystream'
+
+jest.mock('child_process')
+
+type FakeChildProcess = ChildProcessWithoutNullStreams & {
+  endStdout(data?: string | Buffer): Promise<void>
+  endStderr(data?: string | Buffer): Promise<void>
+}
+
+function fakeChildProcess(stdinData?: string | Buffer): FakeChildProcess {
+  const result = new EventEmitter() as FakeChildProcess
+  const stdin = new MemoryStream(stdinData)
+  const stdout = new MemoryStream()
+  const stderr = new MemoryStream()
+
+  Object.defineProperties(result, {
+    stdin: {
+      value: stdin,
+    },
+
+    stdout: {
+      value: stdout,
+    },
+
+    stderr: {
+      value: stderr,
+    },
+
+    endStdout: {
+      value: async (data?: string | Buffer): Promise<void> =>
+        new Promise(resolve => {
+          stdout.end(data, () => {
+            resolve()
+          })
+        }),
+    },
+
+    endStderr: {
+      value: async (data?: string | Buffer): Promise<void> =>
+        new Promise(resolve => {
+          stderr.end(data, () => {
+            resolve()
+          })
+        }),
+    },
+  })
+
+  return result
+}
+
+test('command with no args', async () => {
+  // Set up child process.
+  const child = fakeChildProcess()
+  mockOf(spawn).mockReturnValueOnce(child)
+
+  // Start and finish child process.
+  const execPromise = exec('ls')
+  child.emit('exit', 0, null)
+
+  // Check the results.
+  expect(await execPromise).toEqual({ stdout: '', stderr: '' })
+  expect(spawn).toHaveBeenCalledWith('ls', [])
+})
+
+test('command with args', async () => {
+  // Set up child process.
+  const child = fakeChildProcess()
+  mockOf(spawn).mockReturnValueOnce(child)
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-la'])
+  child.emit('exit', 0, null)
+
+  // Check the results.
+  expect(await execPromise).toEqual({ stdout: '', stderr: '' })
+  expect(spawn).toHaveBeenCalledWith('ls', ['-la'])
+})
+
+test('command printing stdout', async () => {
+  // Set up child process.
+  const child = fakeChildProcess()
+  mockOf(spawn).mockReturnValueOnce(child)
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-la'])
+  await child.endStdout('README.md\n')
+  child.emit('exit', 0, null)
+
+  // Check the results.
+  expect(await execPromise).toEqual({ stdout: 'README.md\n', stderr: '' })
+  expect(spawn).toHaveBeenCalledWith('ls', ['-la'])
+})
+
+test('failed command printing stderr', async () => {
+  // Set up child process.
+  const child = fakeChildProcess()
+  mockOf(spawn).mockReturnValueOnce(child)
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-x'])
+  await child.endStderr('unknown option "-x"')
+  child.emit('exit', 1, null)
+
+  // Check the results.
+  await expect(execPromise).rejects.toThrowError(
+    expect.objectContaining({ stderr: 'unknown option "-x"', code: 1 }),
+  )
+  expect(spawn).toHaveBeenCalledWith('ls', ['-x'])
+})
+
+test('failed command printing stderr', async () => {
+  // Set up child process.
+  const child = fakeChildProcess()
+  mockOf(spawn).mockReturnValueOnce(child)
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-x'])
+  await child.endStderr('unknown option "-x"')
+  child.emit('exit', 1, null)
+
+  // Check the results.
+  await expect(execPromise).rejects.toThrowError(
+    expect.objectContaining({
+      stdout: '',
+      stderr: 'unknown option "-x"',
+      code: 1,
+    }),
+  )
+  expect(spawn).toHaveBeenCalledWith('ls', ['-x'])
+})

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,8 +1,63 @@
-import { execFile } from 'child_process'
-import { promisify } from 'util'
+import { spawn } from 'child_process'
+import makeDebug from 'debug'
 
-// This is here mainly to make mocking easier.
-export default promisify(execFile)
+const debug = makeDebug('kiosk-browser:exec')
+
+/**
+ * Like `child_process.exec`, but with easy stdin.
+ */
+export default async function exec(
+  file: string,
+  args: readonly string[] = [],
+  stdin?: string | Buffer,
+): Promise<{ stdout: string; stderr: string }> {
+  const child = spawn(file, args)
+  let stdout = ''
+  let stderr = ''
+
+  debug(
+    'running command=%s args=%o stdin=%s pid=%d',
+    file,
+    args,
+    typeof stdin,
+    child.pid,
+  )
+
+  child.stdout.on('data', chunk => {
+    stdout += chunk
+  })
+
+  child.stderr.on('data', chunk => {
+    stderr += chunk
+  })
+
+  return new Promise((resolve, reject) => {
+    child.on('exit', (code, signal) => {
+      debug(
+        'process %d exited with code=%d, signal=%s (command=%s args=%o)',
+        child.pid,
+        code,
+        signal,
+        file,
+        args,
+      )
+
+      if (code === 0) {
+        resolve({ stdout, stderr })
+      } else {
+        reject(
+          makeExecError({
+            code: code ?? undefined,
+            signal,
+            stdout,
+            stderr,
+            cmd: file,
+          }),
+        )
+      }
+    })
+  })
+}
 
 export interface ExecError {
   code: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,6 +685,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/memorystream@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/memorystream/-/memorystream-0.3.0.tgz#7616df4c42a479805d052a058d990b879d5e368f"
+  integrity sha512-gzh6mqZcLryYHn4g2MuMWjo9J1+Py/XYwITyZmUxV7ZoBIi7bTbBgSiuC5tcm3UL3gmaiYssQFDlXr/3fK94cw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -714,11 +721,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/tmp@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
-  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -4070,6 +4072,11 @@ mem@^4.3.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@^3.1.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -5987,7 +5994,7 @@ tmp-promise@^1.0.5:
     bluebird "^3.5.0"
     tmp "0.1.0"
 
-tmp-promise@^2.0.1, tmp-promise@^2.0.2:
+tmp-promise@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.0.2.tgz#ee605edb10f100954be5dd8b9dbe1bfd56194202"
   integrity sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==


### PR DESCRIPTION
If we never write a temp file to disk we never run the risk of that data being preserved longer than we want it to be.