### PR TITLE
fix: disable devtools in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,19 +21,6 @@ app.commandLine.appendSwitch('enable-speech-dispatcher')
 let mainWindow: Electron.BrowserWindow | undefined
 
 async function createWindow(): Promise<void> {
-  const mainScreen = await getMainScreen()
-
-  // Create the browser window.
-  mainWindow = new BrowserWindow({
-    width: mainScreen?.width ?? 800,
-    height: mainScreen?.height ?? 600,
-    kiosk: true,
-    frame: false,
-    webPreferences: {
-      preload: join(__dirname, 'preload.js'),
-    },
-  })
-
   const options = await parseOptions(
     // https://github.com/electron/electron/issues/4690
     process.argv.slice(app.isPackaged ? 1 : 2),
@@ -50,6 +37,20 @@ async function createWindow(): Promise<void> {
     app.quit()
     return
   }
+
+  const mainScreen = await getMainScreen()
+
+  // Create the browser window.
+  mainWindow = new BrowserWindow({
+    width: mainScreen?.width ?? 800,
+    height: mainScreen?.height ?? 600,
+    kiosk: true,
+    frame: false,
+    webPreferences: {
+      devTools: options.allowDevtools || !app.isPackaged,
+      preload: join(__dirname, 'preload.js'),
+    },
+  })
 
   const autoconfigurePrinterListener =
     options.autoconfigurePrintConfig &&

--- a/src/utils/options.test.ts
+++ b/src/utils/options.test.ts
@@ -34,3 +34,25 @@ test('falls back to about:blank if nothing else is given', async () => {
   const options = await parseOptionsWithoutHelp()
   expect(options.url.href).toEqual('about:blank')
 })
+
+test('allow devtools', async () => {
+  expect(await parseOptionsWithoutHelp()).not.toEqual(
+    expect.objectContaining({
+      allowDevtools: true,
+    }),
+  )
+
+  expect(await parseOptionsWithoutHelp(['--allow-devtools'])).toEqual(
+    expect.objectContaining({
+      allowDevtools: true,
+    }),
+  )
+
+  expect(
+    await parseOptionsWithoutHelp([], { KIOSK_BROWSER_ALLOW_DEVTOOLS: 'true' }),
+  ).toEqual(
+    expect.objectContaining({
+      allowDevtools: true,
+    }),
+  )
+})


### PR DESCRIPTION
Disallow devtools access  by default when packaged. Devtools may still be opened with Ctrl+Shift+I in development.