### PR TITLE
ci: try to fix native package installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
           node-version: '12.x'
 
       - name: Install Native Dependencies
-        run: sudo apt-get install libudev-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libudev-dev
 
       - name: Get yarn cache
         id: yarn-cache


### PR DESCRIPTION
All builds are failing with this:

```
Err:1 http://azure.archive.ubuntu.com/ubuntu bionic-updates/main amd64 libudev-dev amd64 237-3ubuntu10.33
  404  Not Found [IP: 52.177.174.250 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_237-3ubuntu10.33_amd64.deb  404  Not Found [IP: 52.177.174.250 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```