### PR TITLE
refactor: make USB drive code more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Prints the current page using the default printer. This is different from `windo
 
 Presents a file save dialog to the user and, if a file is chosen, resolves to an object with `write(data)` and `end()` methods, similar to `fs.WriteStream` from `NodeJS`. To use this API, the requesting hostname must be allowed explicitly. For example, via `--allowed-save-as-hostname-pattern localhost`. Additionally, file write destination paths must be explicitly allowed. For example, `--allowed-save-as-destination-pattern /media/**/*`. To allow all hosts and paths, use `--allowed-save-as-hostname-pattern '*' --allowed-save-as-destination-pattern '**/*'`.
 
+`kiosk.`**`getUsbDrives`**`(): Promise<{ deviceName: string; mountPoint?: string }>`
+
+Gets a list of USB drives and, if mounted, where. To mount or unmount a drive, pass its device name to `kiosk.mountUsbDrive` or `kiosk.unmountUsbDrive`.
+
 ## Auto-Configure Printers
 
 If you need to print, `kiosk-browser` can automatically configure printers for you as they are detected. To do so, build a printer config file as described by `kiosk-browser --help`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,14 @@ import { join } from 'path'
 import registerManageDeviceSubscriptionHandler from './ipc/device-subscription'
 import registerGetBatteryInfoHandler from './ipc/get-battery-info'
 import registerGetPrinterInfoHandler from './ipc/get-printer-info'
+import registerGetUsbDrivesHandler from './ipc/get-usb-drives'
+import registerMountUsbDriveHandler from './ipc/mount-usb-drive'
 import registerPrintHandler from './ipc/print'
 import registerPrintToPDFHandler from './ipc/printToPDF'
 import registerQuitHandler from './ipc/quit'
 import registerSaveAsHandler from './ipc/saveAs'
-import registerGetUsbDrives from './ipc/get-usb-drives'
-import registerMountUsbDrive from './ipc/mount-usb-drive'
-import registerUnmountUsbDrive from './ipc/unmount-usb-drive'
-import parseOptions, { printHelp, Options } from './utils/options'
+import registerUnmountUsbDriveHandler from './ipc/unmount-usb-drive'
+import parseOptions, { Options, printHelp } from './utils/options'
 import autoconfigurePrint from './utils/printing/autoconfigurePrinter'
 import { getMainScreen } from './utils/screen'
 import { devices } from './utils/usb'
@@ -78,9 +78,9 @@ async function createWindow(): Promise<void> {
     registerPrintToPDFHandler,
     registerQuitHandler,
     registerSaveAsHandler,
-    registerGetUsbDrives,
-    registerMountUsbDrive,
-    registerUnmountUsbDrive,
+    registerGetUsbDrivesHandler,
+    registerMountUsbDriveHandler,
+    registerUnmountUsbDriveHandler,
   ]
 
   const handlerCleanups = handlers

--- a/src/ipc/mount-usb-drive.ts
+++ b/src/ipc/mount-usb-drive.ts
@@ -1,4 +1,5 @@
-import { IpcMainInvokeEvent, IpcMain } from 'electron'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { join } from 'path'
 import exec from '../utils/exec'
 
 export const channel = 'mountUsbDrive'
@@ -8,8 +9,8 @@ async function mountUsbDrive(device: string): Promise<void> {
     '-w',
     '-u',
     '000',
-    '/dev/' + device,
-    'usb-drive-' + device,
+    join('/dev', device),
+    `usb-drive-${device}`,
   ])
 }
 

--- a/src/ipc/unmount-usb-drive.test.ts
+++ b/src/ipc/unmount-usb-drive.test.ts
@@ -1,7 +1,7 @@
-import register, { channel } from './unmount-usb-drive'
 import { IpcMain } from 'electron'
-import exec from '../utils/exec'
 import mockOf from '../../test/mockOf'
+import exec from '../utils/exec'
+import register, { channel } from './unmount-usb-drive'
 
 const execMock = mockOf(exec)
 

--- a/src/ipc/unmount-usb-drive.ts
+++ b/src/ipc/unmount-usb-drive.ts
@@ -1,10 +1,11 @@
-import { IpcMainInvokeEvent, IpcMain, PrinterInfo } from 'electron'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { join } from 'path'
 import exec from '../utils/exec'
 
 export const channel = 'unmountUsbDrive'
 
 async function unmountUsbDrive(device: string): Promise<void> {
-  await exec('pumount', ['/dev/' + device])
+  await exec('pumount', [join('/dev', device)])
 }
 
 export default function register(ipcMain: IpcMain): void {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -71,12 +71,12 @@ class Kiosk implements KioskBrowser.Kiosk {
     return ipcRenderer.invoke(getUsbDrivesChannel)
   }
 
-  public async mountUsbDrive(device: string) {
+  public async mountUsbDrive(device: string): Promise<void> {
     debug('forwarding `mountUsbDrive` to main process')
     return ipcRenderer.invoke(mountUsbDriveChannel, device)
   }
 
-  public async unmountUsbDrive(device: string) {
+  public async unmountUsbDrive(device: string): Promise<void> {
     debug('forwarding `unmountUsbDrive` to main process')
     return ipcRenderer.invoke(unmountUsbDriveChannel, device)
   }


### PR DESCRIPTION
- use `fs` module for file system operations
- use `path.join` for path manipulation
- organize imports
- fix lint warnings