### PR TITLE
feat(saveAs): allow passing options to save dialog

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -11,14 +11,15 @@ import {
 } from './ipc/get-printer-info'
 import { channel as getUsbDrivesChannel, UsbDrive } from './ipc/get-usb-drives'
 import { channel as mountUsbDriveChannel } from './ipc/mount-usb-drive'
-import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive'
-import { channel as storageSetChannel } from './ipc/storage-set'
-import { channel as storageGetChannel } from './ipc/storage-get'
-import { channel as storageRemoveChannel } from './ipc/storage-remove'
-import { channel as storageClearChannel } from './ipc/storage-clear'
 import { channel as printChannel } from './ipc/print'
 import { channel as printToPDFChannel } from './ipc/printToPDF'
 import { channel as quitChannel } from './ipc/quit'
+import { PromptToSaveOptions } from './ipc/saveAs'
+import { channel as storageClearChannel } from './ipc/storage-clear'
+import { channel as storageGetChannel } from './ipc/storage-get'
+import { channel as storageRemoveChannel } from './ipc/storage-remove'
+import { channel as storageSetChannel } from './ipc/storage-set'
+import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive'
 import buildDevicesObservable from './utils/buildDevicesObservable'
 import FileWriter from './utils/FileWriter'
 
@@ -118,8 +119,10 @@ class Kiosk implements KioskBrowser.Kiosk {
    */
   public devices = buildDevicesObservable(ipcRenderer)
 
-  public async saveAs(): Promise<FileWriter | undefined> {
-    return await FileWriter.fromPrompt()
+  public async saveAs(
+    options?: PromptToSaveOptions,
+  ): Promise<FileWriter | undefined> {
+    return await FileWriter.fromPrompt(options)
   }
 
   public quit(): void {

--- a/src/utils/FileWriter.test.ts
+++ b/src/utils/FileWriter.test.ts
@@ -16,13 +16,13 @@ function fakeClient(): jest.Mocked<Client> {
 test('creating from prompt fails', async () => {
   const client = fakeClient()
   client.promptToSave.mockResolvedValueOnce(undefined)
-  expect(await FileWriter.fromPrompt(client)).toEqual(undefined)
+  expect(await FileWriter.fromPrompt({}, client)).toEqual(undefined)
 })
 
 test('creating from prompt succeeds', async () => {
   const client = fakeClient()
   client.promptToSave.mockResolvedValueOnce({ fd: 42 })
-  expect(await FileWriter.fromPrompt(client)).toBeInstanceOf(FileWriter)
+  expect(await FileWriter.fromPrompt({}, client)).toBeInstanceOf(FileWriter)
 })
 
 test('write passes the file descriptor and data', async () => {

--- a/src/utils/FileWriter.ts
+++ b/src/utils/FileWriter.ts
@@ -1,4 +1,4 @@
-import { Client, Write } from '../ipc/saveAs'
+import { Client, PromptToSaveOptions, Write } from '../ipc/saveAs'
 
 /**
  * Simple wrapper class to handle writing data to file from a save dialog.
@@ -24,9 +24,10 @@ export default class FileWriter {
    * Prompts the user to choose a file path to write a file to.
    */
   public static async fromPrompt(
+    options?: PromptToSaveOptions,
     client = new Client(),
   ): Promise<FileWriter | undefined> {
-    const output = await client.promptToSave()
+    const output = await client.promptToSave(options)
 
     if (!output) {
       return

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -1,7 +1,9 @@
-import { Device } from 'usb-detection'
 import { Observable } from 'rxjs'
-import { PrinterInfo } from '../src/ipc/get-printer-info'
+import { Device } from 'usb-detection'
 import { BatteryInfo } from '../src/ipc/get-battery-info'
+import { PrinterInfo } from '../src/ipc/get-printer-info'
+import { PromptToSaveOptions } from '../src/ipc/saveAs'
+import FileWriter from '../src/utils/FileWriter'
 
 declare namespace KioskBrowser {
   interface PrintOptions {
@@ -20,6 +22,7 @@ declare namespace KioskBrowser {
       paperSource?: string,
       copies?: number,
     ): Promise<void>
+    saveAs(options?: PromptToSaveOptions): Promise<FileWriter | undefined>
     quit(): void
   }
 }


### PR DESCRIPTION
Primarily, this allows setting the default suggested file name and/or the directory to present by default in the save dialog. Some options may be macOS-only.