### PR TITLE
feat: add a few file system access APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Generic kiosk-mode browser.
 1. Build a Debian/Ubuntu package with `make build`.
 1. Copy `out/make/deb/x64/kiosk-browser_*_amd64.deb` wherever you want to install it (note wildcard).
 1. Install it with `sudo dpkg -i kiosk-browser_*_amd64.deb` (note wildcard).
-1. Run with the URL you want to visit as a CLI argument (e.g. `kiosk-browser http://example.com/`) or with an environment variable (e.g. `KIOSK_BROWSER_URL=http://example.com/ kiosk-browser`).
+1. Run with the URL you want to visit as a CLI argument (e.g. `kiosk-browser https://example.com/`) or with an environment variable (e.g. `KIOSK_BROWSER_URL=https://example.com/ kiosk-browser`).
 
 ## Kiosk Page API
 
@@ -25,7 +25,7 @@ Prints the current page using the default printer. This is different from `windo
 
 `kiosk.`**`saveAs`**`(): Promise<FileWriter | undefined>`
 
-Presents a file save dialog to the user and, if a file is chosen, resolves to an object with `write(data)` and `end()` methods, similar to `fs.WriteStream` from `NodeJS`. To use this API, the requesting hostname must be allowed to write to disk.
+Presents a file save dialog to the user and, if a file is chosen, resolves to an object with `write(data)` and `end()` methods, similar to `fs.WriteStream` from `NodeJS`. To use this API, the requesting origin must be allowed to write to disk.
 
 `kiosk.`**`getUsbDrives`**`(): Promise<{ deviceName: string; mountPoint?: string }>`
 
@@ -50,7 +50,7 @@ $ kiosk-browser --help
 If something isn't working as you'd expect it to, try running with debug logging:
 
 ```
-$ DEBUG=kiosk-browser:* kiosk-browser http://example.com/
+$ DEBUG=kiosk-browser:* kiosk-browser https://example.com/
 ```
 
 ## Development

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,15 +2,20 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   clearMocks: true,
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts', '!src/index.ts', '!src/preload.ts'],
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx,ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/preload.ts',
+  ],
   modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/out/'],
   coverageThreshold: {
     // TODO: ratchet these up to 100 over time
     global: {
-      statements: 84,
-      branches: 75,
-      lines: 81,
-      functions: 82,
+      statements: 90,
+      branches: 81,
+      functions: 90,
+      lines: 90,
     },
   },
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/jest": "^24.9.0",
     "@types/memorystream": "^0.3.0",
     "@types/node": "12",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^2.15.0",
     "@typescript-eslint/parser": "^2.15.0",
     "electron": "7.2.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ import { join } from 'path'
 import registerManageDeviceSubscriptionHandler from './ipc/device-subscription'
 import registerGetBatteryInfoHandler from './ipc/get-battery-info'
 import registerGetPrinterInfoHandler from './ipc/get-printer-info'
+import registerFileSystemGetEntriesHandler from './ipc/file-system-get-entries'
+import registerFileSystemReadFileHandler from './ipc/file-system-read-file'
+import registerFileSystemWriteFileHandler from './ipc/file-system-write-file'
 import registerGetUsbDrivesHandler from './ipc/get-usb-drives'
 import registerMountUsbDriveHandler from './ipc/mount-usb-drive'
 import registerPrintHandler from './ipc/print'
@@ -84,6 +87,9 @@ async function createWindow(): Promise<void> {
     registerPrintToPDFHandler,
     registerQuitHandler,
     registerSaveAsHandler,
+    registerFileSystemGetEntriesHandler,
+    registerFileSystemReadFileHandler,
+    registerFileSystemWriteFileHandler,
     registerGetUsbDrivesHandler,
     registerMountUsbDriveHandler,
     registerUnmountUsbDriveHandler,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import registerManageDeviceSubscriptionHandler from './ipc/device-subscription'
 import registerGetBatteryInfoHandler from './ipc/get-battery-info'
 import registerGetPrinterInfoHandler from './ipc/get-printer-info'
 import registerFileSystemGetEntriesHandler from './ipc/file-system-get-entries'
+import registerFileSystemMakeDirectoryHandler from './ipc/file-system-make-directory'
 import registerFileSystemReadFileHandler from './ipc/file-system-read-file'
 import registerFileSystemWriteFileHandler from './ipc/file-system-write-file'
 import registerGetUsbDrivesHandler from './ipc/get-usb-drives'
@@ -88,6 +89,7 @@ async function createWindow(): Promise<void> {
     registerQuitHandler,
     registerSaveAsHandler,
     registerFileSystemGetEntriesHandler,
+    registerFileSystemMakeDirectoryHandler,
     registerFileSystemReadFileHandler,
     registerFileSystemWriteFileHandler,
     registerGetUsbDrivesHandler,

--- a/src/ipc/file-system-get-entries.test.ts
+++ b/src/ipc/file-system-get-entries.test.ts
@@ -38,8 +38,8 @@ test('gets entries with stat info', async () => {
 
   expect(
     await getEntries(
-      [{ hostnames: 'example.com', paths: '**/*', access: 'ro' }],
-      'example.com',
+      [{ origins: 'https://example.com', paths: '**/*', access: 'ro' }],
+      'https://example.com',
       '/a/path',
     ),
   ).toEqual([
@@ -86,14 +86,14 @@ test('registers a handler to get directory entries', async () => {
   const { ipcMain, ipcRenderer } = fakeIpc()
 
   register(ipcMain, {
-    hostFilePermissions: [
+    originFilePermissions: [
       {
-        hostnames: 'example.com',
+        origins: 'https://example.com',
         paths: '**/*',
         access: 'ro',
       },
     ],
-    url: new URL('http://example.com/'),
+    url: new URL('https://example.com/'),
   })
 
   jest.spyOn(fs, 'readdir').mockResolvedValueOnce([])

--- a/src/ipc/file-system-get-entries.test.ts
+++ b/src/ipc/file-system-get-entries.test.ts
@@ -1,0 +1,135 @@
+import { promises as fs, Stats } from 'fs'
+import { fakeIpc } from '../../test/ipc'
+import register, {
+  channel as fileSystemGetEntriesChannel,
+  getEntries,
+} from './file-system-get-entries'
+
+jest.mock('fs', () => ({
+  promises: {
+    readdir: jest
+      .fn()
+      .mockRejectedValue(new Error('ENOENT no mock value provided')),
+    stat: jest
+      .fn()
+      .mockRejectedValue(new Error('ENOENT no mock value provided')),
+  },
+}))
+
+test('gets entries with stat info', async () => {
+  jest
+    .spyOn(fs, 'readdir')
+    .mockResolvedValueOnce(['a.txt', 'b.json', 'c.csv', 'd.png'] as never)
+
+  // a.txt
+  jest.spyOn(fs, 'stat').mockResolvedValueOnce({
+    size: 1,
+    isDirectory: () => false,
+    isFile: () => true,
+    mtime: new Date(0),
+    atime: new Date(0),
+    ctime: new Date(0),
+  } as Stats)
+
+  // b.json
+  jest.spyOn(fs, 'stat').mockResolvedValueOnce({
+    size: 2,
+    isDirectory: () => false,
+    isFile: () => true,
+    mtime: new Date(0),
+    atime: new Date(0),
+    ctime: new Date(0),
+  } as Stats)
+
+  // c.csv
+  jest.spyOn(fs, 'stat').mockResolvedValueOnce({
+    size: 3,
+    isDirectory: () => false,
+    isFile: () => true,
+    mtime: new Date(0),
+    atime: new Date(0),
+    ctime: new Date(0),
+  } as Stats)
+
+  // d.png
+  jest.spyOn(fs, 'stat').mockResolvedValueOnce({
+    size: 4,
+    isDirectory: () => false,
+    isFile: () => true,
+    mtime: new Date(0),
+    atime: new Date(0),
+    ctime: new Date(0),
+  } as Stats)
+
+  expect(
+    await getEntries(
+      [{ hostnames: 'example.com', paths: '**/*', access: 'ro' }],
+      'example.com',
+      '/a/path',
+    ),
+  ).toEqual([
+    {
+      name: 'a.txt',
+      path: '/a/path/a.txt',
+      size: 1,
+      isDirectory: false,
+      isFile: true,
+      mtime: new Date(0),
+      atime: new Date(0),
+      ctime: new Date(0),
+    },
+    {
+      name: 'b.json',
+      path: '/a/path/b.json',
+      size: 2,
+      isDirectory: false,
+      isFile: true,
+      mtime: new Date(0),
+      atime: new Date(0),
+      ctime: new Date(0),
+    },
+    {
+      name: 'c.csv',
+      path: '/a/path/c.csv',
+      size: 3,
+      isDirectory: false,
+      isFile: true,
+      mtime: new Date(0),
+      atime: new Date(0),
+      ctime: new Date(0),
+    },
+    {
+      name: 'd.png',
+      path: '/a/path/d.png',
+      size: 4,
+      isDirectory: false,
+      isFile: true,
+      mtime: new Date(0),
+      atime: new Date(0),
+      ctime: new Date(0),
+    },
+  ])
+})
+
+test('registers a handler to get directory entries', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc()
+
+  register(ipcMain, {
+    hostFilePermissions: [
+      {
+        hostnames: 'example.com',
+        paths: '**/*',
+        access: 'ro',
+      },
+    ],
+    url: new URL('http://example.com/'),
+  })
+
+  jest.spyOn(fs, 'readdir').mockResolvedValueOnce([])
+
+  expect(
+    await ipcRenderer.invoke(fileSystemGetEntriesChannel, '/a/path'),
+  ).toEqual([])
+
+  expect(fs.readdir).toHaveBeenCalledWith('/a/path')
+})

--- a/src/ipc/file-system-get-entries.test.ts
+++ b/src/ipc/file-system-get-entries.test.ts
@@ -3,7 +3,7 @@ import { basename } from 'path'
 import { fakeIpc } from '../../test/ipc'
 import register, {
   channel as fileSystemGetEntriesChannel,
-  DirentType,
+  FileSystemEntryType,
   getDirentType,
   getEntries,
 } from './file-system-get-entries'
@@ -11,14 +11,14 @@ import register, {
 // Dirent types treat the constructor as private.
 const ConstructableDirent = (Dirent as unknown) as new (
   name: string,
-  type: DirentType,
+  type: FileSystemEntryType,
 ) => Dirent
 
 const file = (name: string): Dirent =>
-  new ConstructableDirent(name, DirentType.File)
+  new ConstructableDirent(name, FileSystemEntryType.File)
 
 const symlink = (name: string): Dirent =>
-  new ConstructableDirent(name, DirentType.SymbolicLink)
+  new ConstructableDirent(name, FileSystemEntryType.SymbolicLink)
 
 test('gets entries with stat info', async () => {
   const entries = [file('a.txt'), file('b.json'), file('c.csv'), file('d.png')]
@@ -51,7 +51,7 @@ test('gets entries with stat info', async () => {
       name: 'a.txt',
       path: '/a/path/a.txt',
       size: 1,
-      type: DirentType.File,
+      type: FileSystemEntryType.File,
       mtime: new Date(0),
       atime: new Date(0),
       ctime: new Date(0),
@@ -60,7 +60,7 @@ test('gets entries with stat info', async () => {
       name: 'b.json',
       path: '/a/path/b.json',
       size: 2,
-      type: DirentType.File,
+      type: FileSystemEntryType.File,
       mtime: new Date(0),
       atime: new Date(0),
       ctime: new Date(0),
@@ -69,7 +69,7 @@ test('gets entries with stat info', async () => {
       name: 'c.csv',
       path: '/a/path/c.csv',
       size: 3,
-      type: DirentType.File,
+      type: FileSystemEntryType.File,
       mtime: new Date(0),
       atime: new Date(0),
       ctime: new Date(0),
@@ -78,7 +78,7 @@ test('gets entries with stat info', async () => {
       name: 'd.png',
       path: '/a/path/d.png',
       size: 4,
-      type: DirentType.File,
+      type: FileSystemEntryType.File,
       mtime: new Date(0),
       atime: new Date(0),
       ctime: new Date(0),
@@ -117,7 +117,7 @@ test('filters out symlinks', async () => {
       name: 'a.txt',
       path: '/a/path/a.txt',
       size: 1,
-      type: DirentType.File,
+      type: FileSystemEntryType.File,
       mtime: new Date(0),
       atime: new Date(0),
       ctime: new Date(0),
@@ -150,13 +150,13 @@ test('registers a handler to get directory entries', async () => {
 
 test('getDirentType maps dirent to type properly', () => {
   for (const type of [
-    DirentType.File,
-    DirentType.Directory,
-    DirentType.SymbolicLink,
-    DirentType.FIFO,
-    DirentType.Socket,
-    DirentType.CharacterDevice,
-    DirentType.BlockDevice,
+    FileSystemEntryType.File,
+    FileSystemEntryType.Directory,
+    FileSystemEntryType.SymbolicLink,
+    FileSystemEntryType.FIFO,
+    FileSystemEntryType.Socket,
+    FileSystemEntryType.CharacterDevice,
+    FileSystemEntryType.BlockDevice,
   ]) {
     expect(getDirentType(new ConstructableDirent('foo', type))).toEqual(type)
   }

--- a/src/ipc/file-system-get-entries.test.ts
+++ b/src/ipc/file-system-get-entries.test.ts
@@ -4,6 +4,7 @@ import { fakeIpc } from '../../test/ipc'
 import register, {
   channel as fileSystemGetEntriesChannel,
   DirentType,
+  getDirentType,
   getEntries,
 } from './file-system-get-entries'
 
@@ -103,4 +104,26 @@ test('registers a handler to get directory entries', async () => {
   ).toEqual([])
 
   expect(fs.readdir).toHaveBeenCalledWith('/a/path', { withFileTypes: true })
+})
+
+test('getDirentType maps dirent to type properly', () => {
+  for (const type of [
+    DirentType.File,
+    DirentType.Directory,
+    DirentType.SymbolicLink,
+    DirentType.FIFO,
+    DirentType.Socket,
+    DirentType.CharacterDevice,
+    DirentType.BlockDevice,
+  ]) {
+    expect(getDirentType(new ConstructableDirent('foo', type))).toEqual(type)
+  }
+})
+
+test('getDirentType throws given something bogus', () => {
+  const unknownDirent = file('foo')
+  jest.spyOn(unknownDirent, 'isFile').mockReturnValue(false)
+  expect(() => getDirentType(unknownDirent)).toThrowError(
+    'dirent is not of a known type',
+  )
 })

--- a/src/ipc/file-system-get-entries.ts
+++ b/src/ipc/file-system-get-entries.ts
@@ -9,7 +9,7 @@ const debug = makeDebug('kiosk-browser:file-system-get-entries')
 
 export const channel = 'file-system-get-entries'
 
-export enum DirentType {
+export enum FileSystemEntryType {
   File = 1, // UV_DIRENT_FILE
   Directory = 2, // UV_DIRENT_DIR
   SymbolicLink = 3, // UV_DIRENT_LINK
@@ -22,21 +22,21 @@ export enum DirentType {
 export interface FileSystemEntry {
   readonly name: string
   readonly path: string
-  readonly type: DirentType
+  readonly type: FileSystemEntryType
   readonly size: number
   readonly mtime: Date
   readonly atime: Date
   readonly ctime: Date
 }
 
-export function getDirentType(dirent: Dirent): DirentType {
-  if (dirent.isFile()) return DirentType.File
-  if (dirent.isDirectory()) return DirentType.Directory
-  if (dirent.isSymbolicLink()) return DirentType.SymbolicLink
-  if (dirent.isFIFO()) return DirentType.FIFO
-  if (dirent.isSocket()) return DirentType.Socket
-  if (dirent.isCharacterDevice()) return DirentType.CharacterDevice
-  if (dirent.isBlockDevice()) return DirentType.BlockDevice
+export function getDirentType(dirent: Dirent): FileSystemEntryType {
+  if (dirent.isFile()) return FileSystemEntryType.File
+  if (dirent.isDirectory()) return FileSystemEntryType.Directory
+  if (dirent.isSymbolicLink()) return FileSystemEntryType.SymbolicLink
+  if (dirent.isFIFO()) return FileSystemEntryType.FIFO
+  if (dirent.isSocket()) return FileSystemEntryType.Socket
+  if (dirent.isCharacterDevice()) return FileSystemEntryType.CharacterDevice
+  if (dirent.isBlockDevice()) return FileSystemEntryType.BlockDevice
   throw new TypeError('dirent is not of a known type')
 }
 

--- a/src/ipc/file-system-get-entries.ts
+++ b/src/ipc/file-system-get-entries.ts
@@ -1,0 +1,63 @@
+import makeDebug from 'debug'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { promises as fs } from 'fs'
+import { isAbsolute, join } from 'path'
+import { assertHasReadAccess, HostFilePermission } from '../utils/access'
+import { Options } from '../utils/options'
+
+const debug = makeDebug('kiosk-browser:file-system-get-entries')
+
+export const channel = 'file-system-get-entries'
+
+export interface FileSystemEntry {
+  readonly name: string
+  readonly path: string
+  readonly isDirectory: boolean
+  readonly isFile: boolean
+  readonly size: number
+  readonly mtime: Date
+  readonly atime: Date
+  readonly ctime: Date
+}
+
+/**
+ * Get entries for a directory, includes stat information for each entry.
+ */
+export async function getEntries(
+  permissions: readonly HostFilePermission[],
+  hostname: string,
+  path: string,
+): Promise<FileSystemEntry[] | undefined> {
+  if (!isAbsolute(path)) {
+    debug('aborting request because it is not an absolute path')
+    throw new Error(`requested path is not absolute: ${path}`)
+  }
+  assertHasReadAccess(permissions, hostname, path)
+
+  const names = await fs.readdir(path)
+  return await Promise.all(
+    names.map(async name => {
+      const entryPath = join(path, name)
+      const stat = await fs.stat(entryPath)
+
+      return {
+        name,
+        path: entryPath,
+        size: stat.size,
+        isDirectory: stat.isDirectory(),
+        isFile: stat.isFile(),
+        mtime: stat.mtime,
+        atime: stat.atime,
+        ctime: stat.ctime,
+      }
+    }),
+  )
+}
+
+export default function register(ipcMain: IpcMain, options: Options): void {
+  ipcMain.handle(channel, async (event: IpcMainInvokeEvent, path: string) => {
+    const url = new URL(event.sender.getURL())
+    const hostname = url.hostname || url.toString()
+    return await getEntries(options.hostFilePermissions, hostname, path)
+  })
+}

--- a/src/ipc/file-system-get-entries.ts
+++ b/src/ipc/file-system-get-entries.ts
@@ -29,7 +29,7 @@ export interface FileSystemEntry {
   readonly ctime: Date
 }
 
-function getDirentType(dirent: Dirent): DirentType {
+export function getDirentType(dirent: Dirent): DirentType {
   if (dirent.isFile()) return DirentType.File
   if (dirent.isDirectory()) return DirentType.Directory
   if (dirent.isSymbolicLink()) return DirentType.SymbolicLink

--- a/src/ipc/file-system-make-directory.test.ts
+++ b/src/ipc/file-system-make-directory.test.ts
@@ -1,0 +1,66 @@
+import { makeDirectory } from './file-system-make-directory'
+import { promises as fs } from 'fs'
+
+jest.mock('fs', () => ({
+  promises: { mkdir: jest.fn() },
+}))
+const mkdirMock = fs.mkdir as jest.MockedFunction<typeof fs.mkdir>
+
+test('fails if the origin has no write permission', async () => {
+  await expect(
+    makeDirectory([], 'evil.com', '/path/to/dir'),
+  ).rejects.toThrowError('evil.com is not allowed to write to /path/to/dir')
+})
+
+test('fails given a non-absolute path', async () => {
+  await expect(
+    makeDirectory(
+      [
+        {
+          origins: 'https://example.com',
+          paths: '/path/to/**/*',
+          access: 'rw',
+        },
+      ],
+      'evil.com',
+      'a/relative/path',
+    ),
+  ).rejects.toThrowError('requested path is not absolute: a/relative/path')
+})
+
+test('makes a directory non-recursively by default', async () => {
+  mkdirMock.mockResolvedValueOnce()
+
+  await makeDirectory(
+    [
+      {
+        origins: 'https://example.com',
+        paths: '/path/to/**/*',
+        access: 'rw',
+      },
+    ],
+    'https://example.com',
+    '/path/to/dir',
+  )
+
+  expect(mkdirMock).toHaveBeenCalledWith('/path/to/dir', {})
+})
+
+test('makes a directory recursively if requested', async () => {
+  mkdirMock.mockResolvedValueOnce()
+
+  await makeDirectory(
+    [
+      {
+        origins: 'https://example.com',
+        paths: '/path/to/**/*',
+        access: 'rw',
+      },
+    ],
+    'https://example.com',
+    '/path/to/dir',
+    { recursive: true },
+  )
+
+  expect(mkdirMock).toHaveBeenCalledWith('/path/to/dir', { recursive: true })
+})

--- a/src/ipc/file-system-make-directory.ts
+++ b/src/ipc/file-system-make-directory.ts
@@ -1,0 +1,45 @@
+import makeDebug from 'debug'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { isAbsolute } from 'path'
+import { assertHasWriteAccess, OriginFilePermission } from '../utils/access'
+import { Options } from '../utils/options'
+import { MakeDirectoryOptions, promises as fs } from 'fs'
+
+const debug = makeDebug('kiosk-browser:file-system-make-directory')
+
+export const channel = 'file-system-make-directory'
+
+export async function makeDirectory(
+  permissions: readonly OriginFilePermission[],
+  origin: string,
+  path: string,
+  options: MakeDirectoryOptions = {},
+): Promise<void> {
+  if (!isAbsolute(path)) {
+    debug('aborting request because it is not an absolute path')
+    throw new Error(`requested path is not absolute: ${path}`)
+  }
+
+  assertHasWriteAccess(permissions, origin, path)
+  debug('%s requested to create %s', origin, path)
+  await fs.mkdir(path, options)
+}
+
+export default function register(ipcMain: IpcMain, options: Options): void {
+  ipcMain.handle(
+    channel,
+    async (
+      event: IpcMainInvokeEvent,
+      path: string,
+      opts: MakeDirectoryOptions,
+    ) => {
+      const url = new URL(event.sender.getURL())
+      return await makeDirectory(
+        options.originFilePermissions,
+        url.origin,
+        path,
+        opts,
+      )
+    },
+  )
+}

--- a/src/ipc/file-system-read-file.test.ts
+++ b/src/ipc/file-system-read-file.test.ts
@@ -7,15 +7,15 @@ import register, {
 
 test('fails when read permission is not present', async () => {
   await expect(
-    readFile('example.com', [], '/a/path', 'utf8'),
+    readFile('https://example.com', [], '/a/path', 'utf8'),
   ).rejects.toThrowError(
-    new Error('example.com is not allowed to read /a/path'),
+    new Error('https://example.com is not allowed to read /a/path'),
   )
 })
 
 test('fails when the file path is not absolute', async () => {
   await expect(
-    readFile('example.com', [], 'some/relative/path', 'utf8'),
+    readFile('https://example.com', [], 'some/relative/path', 'utf8'),
   ).rejects.toThrowError(
     new Error('requested path is not absolute: some/relative/path'),
   )
@@ -26,8 +26,8 @@ test('read files with an encoding', async () => {
 
   expect(
     await readFile(
-      'example.com',
-      [{ hostnames: 'example.com', paths: '/a/path/**/*', access: 'ro' }],
+      'https://example.com',
+      [{ origins: 'https://example.com', paths: '/a/path/**/*', access: 'ro' }],
       '/a/path/to/file.txt',
       'utf8',
     ),
@@ -41,8 +41,8 @@ test('read files without an encoding', async () => {
 
   expect(
     await readFile(
-      'example.com',
-      [{ hostnames: 'example.com', paths: '/a/path/**/*', access: 'ro' }],
+      'https://example.com',
+      [{ origins: 'https://example.com', paths: '/a/path/**/*', access: 'ro' }],
       '/a/path/to/file.png',
     ),
   ).toEqual(Buffer.of(1, 2, 3))
@@ -54,14 +54,14 @@ test('registers a handler to read files', async () => {
   const { ipcMain, ipcRenderer } = fakeIpc()
 
   register(ipcMain, {
-    hostFilePermissions: [
+    originFilePermissions: [
       {
-        hostnames: 'example.com',
+        origins: 'https://example.com',
         paths: '**/*',
         access: 'ro',
       },
     ],
-    url: new URL('http://example.com/'),
+    url: new URL('https://example.com/'),
   })
 
   jest.spyOn(fs, 'readFile').mockResolvedValueOnce('hello world')

--- a/src/ipc/file-system-read-file.test.ts
+++ b/src/ipc/file-system-read-file.test.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from 'fs'
+import { fakeIpc } from '../../test/ipc'
+import register, {
+  channel as fileSystemReadFileChannel,
+  readFile,
+} from './file-system-read-file'
+
+test('fails when read permission is not present', async () => {
+  await expect(
+    readFile('example.com', [], '/a/path', 'utf8'),
+  ).rejects.toThrowError(
+    new Error('example.com is not allowed to read /a/path'),
+  )
+})
+
+test('fails when the file path is not absolute', async () => {
+  await expect(
+    readFile('example.com', [], 'some/relative/path', 'utf8'),
+  ).rejects.toThrowError(
+    new Error('requested path is not absolute: some/relative/path'),
+  )
+})
+
+test('read files with an encoding', async () => {
+  jest.spyOn(fs, 'readFile').mockResolvedValueOnce('file content as a string')
+
+  expect(
+    await readFile(
+      'example.com',
+      [{ hostnames: 'example.com', paths: '/a/path/**/*', access: 'ro' }],
+      '/a/path/to/file.txt',
+      'utf8',
+    ),
+  ).toEqual('file content as a string')
+
+  expect(fs.readFile).toHaveBeenCalledWith('/a/path/to/file.txt', 'utf8')
+})
+
+test('read files without an encoding', async () => {
+  jest.spyOn(fs, 'readFile').mockResolvedValueOnce(Buffer.of(1, 2, 3))
+
+  expect(
+    await readFile(
+      'example.com',
+      [{ hostnames: 'example.com', paths: '/a/path/**/*', access: 'ro' }],
+      '/a/path/to/file.png',
+    ),
+  ).toEqual(Buffer.of(1, 2, 3))
+
+  expect(fs.readFile).toHaveBeenCalledWith('/a/path/to/file.png', undefined)
+})
+
+test('registers a handler to read files', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc()
+
+  register(ipcMain, {
+    hostFilePermissions: [
+      {
+        hostnames: 'example.com',
+        paths: '**/*',
+        access: 'ro',
+      },
+    ],
+    url: new URL('http://example.com/'),
+  })
+
+  jest.spyOn(fs, 'readFile').mockResolvedValueOnce('hello world')
+
+  expect(
+    await ipcRenderer.invoke(fileSystemReadFileChannel, '/a/path', 'utf8'),
+  ).toEqual('hello world')
+
+  expect(fs.readFile).toHaveBeenCalledWith('/a/path', 'utf8')
+})

--- a/src/ipc/file-system-read-file.ts
+++ b/src/ipc/file-system-read-file.ts
@@ -1,0 +1,36 @@
+import makeDebug from 'debug'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { promises as fs } from 'fs'
+import { isAbsolute } from 'path'
+import { assertHasReadAccess, HostFilePermission } from '../utils/access'
+import { Options } from '../utils/options'
+
+const debug = makeDebug('kiosk-browser:file-system-read-file')
+
+export const channel = 'file-system-read-file'
+
+export async function readFile(
+  hostname: string,
+  permissions: readonly HostFilePermission[],
+  path: string,
+  encoding?: string,
+): Promise<Buffer | string> {
+  if (!isAbsolute(path)) {
+    debug('aborting request because it is not an absolute path')
+    throw new Error(`requested path is not absolute: ${path}`)
+  }
+
+  assertHasReadAccess(permissions, hostname, path)
+  return await fs.readFile(path, encoding)
+}
+
+export default function register(ipcMain: IpcMain, options: Options): void {
+  ipcMain.handle(
+    channel,
+    (event: IpcMainInvokeEvent, path: string, encoding?: string) => {
+      const url = new URL(event.sender.getURL())
+      const hostname = url.hostname || url.toString()
+      return readFile(hostname, options.hostFilePermissions, path, encoding)
+    },
+  )
+}

--- a/src/ipc/file-system-write-file.test.ts
+++ b/src/ipc/file-system-write-file.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs, WriteStream } from 'fs'
+import { v4 as uuid } from 'uuid'
 import { fakeIpc } from '../../test/ipc'
 import { OriginFilePermission } from '../utils/access'
 import OpenFiles from '../utils/OpenFiles'
@@ -52,7 +53,7 @@ test('fails when the file has no write permission', () => {
 
 test('open file for writing', () => {
   const files = new OpenFiles()
-  const fd = 1
+  const fd = uuid()
   jest.spyOn(files, 'open').mockReturnValueOnce(fd)
 
   expect(
@@ -75,7 +76,7 @@ test('open and write to a file', async () => {
   const permissions: readonly OriginFilePermission[] = [
     { origins: 'https://example.com', paths: '/a/path/**/*', access: 'rw' },
   ]
-  const fd = 1
+  const fd = uuid()
   const writeMock = jest
     .fn()
     .mockImplementation((_data: unknown, callback: () => void) => callback())

--- a/src/ipc/file-system-write-file.test.ts
+++ b/src/ipc/file-system-write-file.test.ts
@@ -1,0 +1,118 @@
+import { promises as fs, WriteStream } from 'fs'
+import { fakeIpc } from '../../test/ipc'
+import { HostFilePermission } from '../utils/access'
+import OpenFiles from '../utils/OpenFiles'
+import register, {
+  channel as fileSystemWriteFileChannel,
+  end,
+  open,
+  write,
+} from './file-system-write-file'
+
+test('fails when write permission is not present', () => {
+  const files = new OpenFiles()
+  expect(() =>
+    open(files, [], 'example.com', { type: 'Open', path: '/a/path' }),
+  ).toThrowError(new Error('example.com is not allowed to write to disk'))
+})
+
+test('fails when the file path is not absolute', () => {
+  const files = new OpenFiles()
+  expect(() =>
+    open(files, [], 'example.com', {
+      type: 'Open',
+      path: 'some/relative/path',
+    }),
+  ).toThrowError(
+    new Error('requested path is not absolute: some/relative/path'),
+  )
+})
+
+test('open file for writing', () => {
+  const files = new OpenFiles()
+  const fd = 1
+  jest.spyOn(files, 'open').mockReturnValueOnce(fd)
+
+  expect(
+    open(
+      files,
+      [{ hostnames: 'example.com', paths: '/a/path/**/*', access: 'rw' }],
+      'example.com',
+      { type: 'Open', path: '/a/path/to/file.txt' },
+    ),
+  ).toEqual({ fd })
+
+  expect(files.open).toHaveBeenCalledWith('example.com', '/a/path/to/file.txt')
+})
+
+test('open and write to a file', async () => {
+  const files = new OpenFiles()
+  const permissions: readonly HostFilePermission[] = [
+    { hostnames: 'example.com', paths: '/a/path/**/*', access: 'rw' },
+  ]
+  const fd = 1
+  const writeMock = jest
+    .fn()
+    .mockImplementation((_data: unknown, callback: () => void) => callback())
+  jest.spyOn(files, 'open').mockReturnValueOnce(fd)
+  jest
+    .spyOn(files, 'get')
+    .mockReturnValue(({ write: writeMock } as unknown) as WriteStream)
+  jest.spyOn(files, 'close').mockResolvedValueOnce(true)
+
+  open(files, permissions, 'example.com', {
+    type: 'Open',
+    path: '/a/path/to/file.txt',
+  })
+
+  await write(files, permissions, 'example.com', {
+    type: 'Write',
+    fd,
+    data: 'hello ',
+  })
+  await write(files, permissions, 'example.com', {
+    type: 'Write',
+    fd,
+    data: Buffer.of(0x20),
+  })
+  await end(files, permissions, 'example.com', { type: 'End', fd })
+
+  expect(writeMock).toHaveBeenNthCalledWith(1, 'hello ', expect.any(Function))
+  expect(writeMock).toHaveBeenNthCalledWith(
+    2,
+    Buffer.of(0x20),
+    expect.any(Function),
+  )
+  expect(files.close).toHaveBeenCalledWith('example.com', fd)
+})
+
+test('registers a handler to write files', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc()
+
+  register(ipcMain, {
+    hostFilePermissions: [
+      {
+        hostnames: 'example.com',
+        paths: '**/*',
+        access: 'rw',
+      },
+    ],
+    url: new URL('http://example.com/'),
+  })
+
+  const path = '/tmp/kiosk-browser-write-file-test-file'
+  const { fd } = await ipcRenderer.invoke(fileSystemWriteFileChannel, {
+    type: 'Open',
+    path,
+  })
+
+  await ipcRenderer.invoke(fileSystemWriteFileChannel, {
+    type: 'Write',
+    fd,
+    data: 'hello world',
+  })
+
+  await ipcRenderer.invoke(fileSystemWriteFileChannel, { type: 'End', fd })
+
+  expect(await fs.readFile(path, 'utf8')).toEqual('hello world')
+})

--- a/src/ipc/file-system-write-file.test.ts
+++ b/src/ipc/file-system-write-file.test.ts
@@ -14,7 +14,7 @@ test('fails when write permission is not present', () => {
   expect(() =>
     open(files, [], 'https://example.com', { type: 'Open', path: '/a/path' }),
   ).toThrowError(
-    new Error('https://example.com is not allowed to write to disk'),
+    new Error('https://example.com is not allowed to write to /a/path'),
   )
 })
 
@@ -27,6 +27,26 @@ test('fails when the file path is not absolute', () => {
     }),
   ).toThrowError(
     new Error('requested path is not absolute: some/relative/path'),
+  )
+})
+
+test('fails when the file has no write permission', () => {
+  const files = new OpenFiles()
+  expect(() =>
+    open(
+      files,
+      [
+        { origins: 'https://example.com', paths: '/a/**/*', access: 'ro' },
+        { origins: 'https://example.com', paths: '/b/**/*', access: 'wo' },
+      ],
+      'https://example.com',
+      {
+        type: 'Open',
+        path: '/a/path',
+      },
+    ),
+  ).toThrowError(
+    new Error('https://example.com is not allowed to write to /a/path'),
   )
 })
 

--- a/src/ipc/file-system-write-file.ts
+++ b/src/ipc/file-system-write-file.ts
@@ -17,17 +17,17 @@ export interface Open {
 
 export interface Write {
   type: 'Write'
-  fd: number
+  fd: string
   data: Buffer | Uint8Array | string
 }
 
 export interface End {
   type: 'End'
-  fd: number
+  fd: string
 }
 
 export interface OpenResult {
-  fd: number
+  fd: string
 }
 
 /**
@@ -73,7 +73,7 @@ export function open(
   assertHasWriteAccess(permissions, origin, input.path)
   const fd = files.open(origin, input.path)
   debug(
-    '%s: %s opened %s for writing as fd=%d',
+    '%s: %s opened %s for writing as fd=%s',
     input.type,
     origin,
     input.path,
@@ -92,7 +92,7 @@ export async function write(
   const openFile = files.get(origin, input.fd)
 
   if (!openFile) {
-    debug('%s: %s has no open file with fd=%d', input.type, origin, input.fd)
+    debug('%s: %s has no open file with fd=%s', input.type, origin, input.fd)
     throw new Error(`ENOENT: no such file with descriptor '${input.fd}'`)
   }
 
@@ -117,7 +117,7 @@ export async function end(
   const openFile = files.get(origin, input.fd)
 
   if (!openFile) {
-    debug('%s: %s has no open file with fd=%d', input.type, origin, input.fd)
+    debug('%s: %s has no open file with fd=%s', input.type, origin, input.fd)
     throw new Error(`ENOENT: no such file with descriptor '${input.fd}'`)
   }
 

--- a/src/ipc/file-system-write-file.ts
+++ b/src/ipc/file-system-write-file.ts
@@ -1,0 +1,157 @@
+import makeDebug from 'debug'
+import * as electron from 'electron'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { isAbsolute } from 'path'
+import { assertHasWriteAccess, HostFilePermission } from '../utils/access'
+import OpenFiles from '../utils/OpenFiles'
+import { Options } from '../utils/options'
+
+const debug = makeDebug('kiosk-browser:file-system-write-file')
+
+export const channel = 'file-system-write-file'
+
+export interface Open {
+  type: 'Open'
+  path: string
+}
+
+export interface Write {
+  type: 'Write'
+  fd: number
+  data: Buffer | Uint8Array | string
+}
+
+export interface End {
+  type: 'End'
+  fd: number
+}
+
+export interface OpenResult {
+  fd: number
+}
+
+/**
+ * Use from the renderer process to easily send messages to the main process.
+ */
+export class Client {
+  public constructor(
+    protected readonly ipcChannel = channel,
+    protected readonly ipcRenderer = electron.ipcRenderer,
+  ) {}
+
+  protected async invoke(...args: unknown[]): Promise<unknown> {
+    return this.ipcRenderer.invoke(this.ipcChannel, ...args)
+  }
+
+  async open(path: Open['path']): Promise<OpenResult> {
+    const input: Open = { type: 'Open', path }
+    return (await this.invoke(input)) as OpenResult
+  }
+
+  async write(fd: Write['fd'], data: Write['data']): Promise<void> {
+    const input: Write = { type: 'Write', fd, data }
+    await this.invoke(input)
+  }
+
+  async end(fd: Write['fd']): Promise<void> {
+    const input: End = { type: 'End', fd }
+    await this.invoke(input)
+  }
+}
+
+export function open(
+  files: OpenFiles,
+  permissions: readonly HostFilePermission[],
+  hostname: string,
+  input: Open,
+): OpenResult {
+  if (!isAbsolute(input.path)) {
+    debug('aborting request because it is not an absolute path')
+    throw new Error(`requested path is not absolute: ${input.path}`)
+  }
+
+  assertHasWriteAccess(permissions, hostname)
+  const fd = files.open(hostname, input.path)
+  debug(
+    '%s: %s opened %s for writing as fd=%d',
+    input.type,
+    hostname,
+    input.path,
+    fd,
+  )
+  return { fd }
+}
+
+export async function write(
+  files: OpenFiles,
+  permissions: readonly HostFilePermission[],
+  hostname: string,
+  input: Write,
+): Promise<void> {
+  assertHasWriteAccess(permissions, hostname)
+  const openFile = files.get(hostname, input.fd)
+
+  if (!openFile) {
+    debug('%s: %s has no open file with fd=%d', input.type, hostname, input.fd)
+    throw new Error(`ENOENT: no such file with descriptor '${input.fd}'`)
+  }
+
+  debug(
+    '%s: filePath=%s; data length=%d',
+    input.type,
+    openFile.path,
+    input.data.length,
+  )
+  return new Promise((resolve, reject) => {
+    openFile.write(input.data, err => (err ? reject(err) : resolve()))
+  })
+}
+
+export async function end(
+  files: OpenFiles,
+  permissions: readonly HostFilePermission[],
+  hostname: string,
+  input: End,
+): Promise<void> {
+  assertHasWriteAccess(permissions, hostname)
+  const openFile = files.get(hostname, input.fd)
+
+  if (!openFile) {
+    debug('%s: %s has no open file with fd=%d', input.type, hostname, input.fd)
+    throw new Error(`ENOENT: no such file with descriptor '${input.fd}'`)
+  }
+
+  debug('%s: filePath=%s', input.type, openFile.path)
+  await files.close(hostname, input.fd)
+}
+
+export default function register(ipcMain: IpcMain, options: Options): void {
+  const files = new OpenFiles()
+
+  async function handler(
+    event: IpcMainInvokeEvent,
+    input: Open,
+  ): Promise<OpenResult>
+  async function handler(event: IpcMainInvokeEvent, input: Write): Promise<void>
+  async function handler(event: IpcMainInvokeEvent, input: End): Promise<void>
+  async function handler(
+    event: IpcMainInvokeEvent,
+    input: Open | Write | End,
+  ): Promise<OpenResult | void> {
+    const url = new URL(event.sender.getURL())
+    const hostname = url.hostname || url.toString()
+
+    switch (input.type) {
+      case 'Open':
+        return open(files, options.hostFilePermissions, hostname, input)
+
+      case 'Write':
+        return await write(files, options.hostFilePermissions, hostname, input)
+
+      case 'End':
+        return await end(files, options.hostFilePermissions, hostname, input)
+    }
+  }
+
+  ipcMain.handle(channel, handler)
+}

--- a/src/ipc/file-system-write-file.ts
+++ b/src/ipc/file-system-write-file.ts
@@ -70,7 +70,7 @@ export function open(
     throw new Error(`requested path is not absolute: ${input.path}`)
   }
 
-  assertHasWriteAccess(permissions, origin)
+  assertHasWriteAccess(permissions, origin, input.path)
   const fd = files.open(origin, input.path)
   debug(
     '%s: %s opened %s for writing as fd=%d',

--- a/src/ipc/saveAs.test.ts
+++ b/src/ipc/saveAs.test.ts
@@ -21,7 +21,7 @@ test('open, write, close', async () => {
     hostFilePermissions: [{ hostnames: '*', paths: '**/*', access: 'rw' }],
   })
 
-  const client = new Client(ipcRenderer.invoke.bind(ipcRenderer))
+  const client = new Client(ipcRenderer)
 
   // prepare to prompt
   mockOf(electron.dialog.showSaveDialog).mockResolvedValueOnce({
@@ -77,7 +77,7 @@ test('accepts options for the save dialog', async () => {
     hostFilePermissions: [{ hostnames: '*', paths: '**/*', access: 'rw' }],
   })
 
-  const client = new Client(ipcRenderer.invoke.bind(ipcRenderer))
+  const client = new Client(ipcRenderer)
 
   // prepare to prompt
   mockOf(electron.dialog.showSaveDialog).mockResolvedValueOnce({
@@ -154,7 +154,7 @@ test('disallows hosts that are not explicitly listed', async () => {
     hostFilePermissions: [],
   })
 
-  const client = new Client(ipcRenderer.invoke.bind(ipcRenderer))
+  const client = new Client(ipcRenderer)
 
   expect(electron.dialog.showSaveDialog).not.toBeCalled()
   await expect(client.promptToSave()).rejects.toThrowError(
@@ -172,7 +172,7 @@ test('disallows file destinations that are not explicitly listed', async () => {
     ],
   })
 
-  const client = new Client(ipcRenderer.invoke.bind(ipcRenderer))
+  const client = new Client(ipcRenderer)
 
   mockOf(electron.dialog.showSaveDialog).mockResolvedValueOnce({
     canceled: false,
@@ -195,7 +195,7 @@ test('does not allow cross-site file access', async () => {
     hostFilePermissions: [{ hostnames: '*', paths: '**/*', access: 'rw' }],
   })
 
-  const client = new Client(ipcRenderer.invoke.bind(ipcRenderer))
+  const client = new Client(ipcRenderer)
 
   setWebContents({
     getURL() {

--- a/src/ipc/saveAs.test.ts
+++ b/src/ipc/saveAs.test.ts
@@ -18,7 +18,7 @@ test('open, write, close', async () => {
 
   register(ipcMain, {
     url: new URL('https://example.com/'),
-    hostFilePermissions: [{ hostnames: '*', paths: '**/*', access: 'rw' }],
+    originFilePermissions: [{ origins: '**/*', paths: '**/*', access: 'rw' }],
   })
 
   const client = new Client(ipcRenderer)
@@ -74,7 +74,7 @@ test('accepts options for the save dialog', async () => {
 
   register(ipcMain, {
     url: new URL('https://example.com/'),
-    hostFilePermissions: [{ hostnames: '*', paths: '**/*', access: 'rw' }],
+    originFilePermissions: [{ origins: '**/*', paths: '**/*', access: 'rw' }],
   })
 
   const client = new Client(ipcRenderer)
@@ -142,7 +142,7 @@ test('accepts options for the save dialog', async () => {
 })
 
 test('disallows hosts that are not explicitly listed', async () => {
-  const url = new URL('https://evil.com/')
+  const url = new URL('http://evil.com/')
   const { ipcMain, ipcRenderer } = fakeIpc({
     getURL() {
       return url.toString()
@@ -151,7 +151,7 @@ test('disallows hosts that are not explicitly listed', async () => {
 
   register(ipcMain, {
     url,
-    hostFilePermissions: [],
+    originFilePermissions: [],
   })
 
   const client = new Client(ipcRenderer)
@@ -167,8 +167,8 @@ test('disallows file destinations that are not explicitly listed', async () => {
 
   register(ipcMain, {
     url: new URL('https://example.com/'),
-    hostFilePermissions: [
-      { hostnames: 'example.com', paths: '/media/**/*', access: 'rw' },
+    originFilePermissions: [
+      { origins: 'https://example.com', paths: '/media/**/*', access: 'rw' },
     ],
   })
 
@@ -192,7 +192,7 @@ test('does not allow cross-site file access', async () => {
 
   register(ipcMain, {
     url: new URL('https://example.com/'),
-    hostFilePermissions: [{ hostnames: '*', paths: '**/*', access: 'rw' }],
+    originFilePermissions: [{ origins: '**/*', paths: '**/*', access: 'rw' }],
   })
 
   const client = new Client(ipcRenderer)
@@ -228,7 +228,7 @@ test('does not allow cross-site file access', async () => {
 
   setWebContents({
     getURL() {
-      return 'https://evil.com/'
+      return 'http://evil.com/'
     },
   })
 

--- a/src/ipc/saveAs.ts
+++ b/src/ipc/saveAs.ts
@@ -31,7 +31,7 @@ export type PromptToSaveOptions = Pick<
   'title' | 'defaultPath' | 'buttonLabel' | 'filters'
 >
 export type PromptToSaveResult =
-  | { type: 'file'; fd: number }
+  | { type: 'file'; fd: string }
   | { type: 'cancel' }
 
 /**
@@ -67,7 +67,7 @@ async function handlePromptToSave(
   assertHasWriteAccess(permissions, origin, result.filePath)
 
   const fd = files.open(origin, result.filePath)
-  debug('%s: opened %s for writing as fd=%d', input.type, result.filePath, fd)
+  debug('%s: opened %s for writing as fd=%s', input.type, result.filePath, fd)
   return { type: 'file', fd }
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,11 +1,13 @@
 import makeDebug from 'debug'
 import { ipcRenderer } from 'electron'
+import { MakeDirectoryOptions } from 'fs'
 import { KioskBrowser } from '../types/kiosk-window'
 import { channel as setClock } from './ipc/clock'
 import {
   channel as fileSystemGetEntriesChannel,
   FileSystemEntry,
 } from './ipc/file-system-get-entries'
+import { channel as fileSystemMakeDirectory } from './ipc/file-system-make-directory'
 import { channel as fileSystemReadFileChannel } from './ipc/file-system-read-file'
 import {
   BatteryInfo,
@@ -134,6 +136,14 @@ class Kiosk implements KioskBrowser.Kiosk {
     } else {
       return writer
     }
+  }
+
+  public async makeDirectory(
+    path: string,
+    options: MakeDirectoryOptions = {},
+  ): Promise<void> {
+    debug('forwarding `makeDirectory` to main process')
+    return ipcRenderer.invoke(fileSystemMakeDirectory, path, options)
   }
 
   public storage = {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -27,7 +27,7 @@ import { channel as storageRemoveChannel } from './ipc/storage-remove'
 import { channel as storageSetChannel } from './ipc/storage-set'
 import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive'
 import buildDevicesObservable from './utils/buildDevicesObservable'
-import FileWriter from './utils/FileWriter'
+import { FileWriter, fromPath, fromPrompt } from './utils/FileWriter'
 
 const debug = makeDebug('kiosk-browser:client')
 
@@ -126,7 +126,7 @@ class Kiosk implements KioskBrowser.Kiosk {
     content?: Buffer | string,
   ): Promise<FileWriter | void> {
     debug('forwarding `writeFile` to main process')
-    const writer = await FileWriter.fromPath(path)
+    const writer = await fromPath(path)
 
     if (typeof content !== 'undefined') {
       await writer.write(content)
@@ -177,7 +177,7 @@ class Kiosk implements KioskBrowser.Kiosk {
   public async saveAs(
     options?: PromptToSaveOptions,
   ): Promise<FileWriter | undefined> {
-    return await FileWriter.fromPrompt(options)
+    return await fromPrompt(options)
   }
 
   public quit(): void {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -31,6 +31,12 @@ import FileWriter from './utils/FileWriter'
 
 const debug = makeDebug('kiosk-browser:client')
 
+function toDate(dateOrString: Date | string): Date {
+  return typeof dateOrString === 'string'
+    ? new Date(dateOrString)
+    : dateOrString
+}
+
 class Kiosk implements KioskBrowser.Kiosk {
   public async print(options?: KioskBrowser.PrintOptions): Promise<void>
   public async print(
@@ -100,12 +106,9 @@ class Kiosk implements KioskBrowser.Kiosk {
     )
     return result.map(entry => ({
       ...entry,
-      mtime:
-        typeof entry.mtime === 'string' ? new Date(entry.mtime) : entry.mtime,
-      atime:
-        typeof entry.atime === 'string' ? new Date(entry.atime) : entry.atime,
-      ctime:
-        typeof entry.ctime === 'string' ? new Date(entry.ctime) : entry.ctime,
+      mtime: toDate(entry.mtime),
+      atime: toDate(entry.atime),
+      ctime: toDate(entry.ctime),
     }))
   }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,6 +6,7 @@ import { channel as setClock } from './ipc/clock'
 import {
   channel as fileSystemGetEntriesChannel,
   FileSystemEntry,
+  FileSystemEntryType,
 } from './ipc/file-system-get-entries'
 import { channel as fileSystemMakeDirectory } from './ipc/file-system-make-directory'
 import { channel as fileSystemReadFileChannel } from './ipc/file-system-read-file'
@@ -99,6 +100,8 @@ class Kiosk implements KioskBrowser.Kiosk {
     debug('forwarding `unmountUsbDrive` to main process')
     return ipcRenderer.invoke(unmountUsbDriveChannel, device)
   }
+
+  public FileSystemEntryType = FileSystemEntryType
 
   public async getFileSystemEntries(path: string): Promise<FileSystemEntry[]> {
     debug('forwarding `getFileSystemEntries` to main process')

--- a/src/utils/FileWriter.test.ts
+++ b/src/utils/FileWriter.test.ts
@@ -1,6 +1,6 @@
 import { fakeIpc } from '../../test/ipc'
 import { Client } from '../ipc/saveAs'
-import FileWriter from './FileWriter'
+import { create, fromPrompt } from './FileWriter'
 
 function fakeClient(): jest.Mocked<Client> {
   const { ipcRenderer } = fakeIpc()
@@ -16,25 +16,28 @@ function fakeClient(): jest.Mocked<Client> {
 test('creating from prompt fails', async () => {
   const client = fakeClient()
   client.promptToSave.mockResolvedValueOnce({ type: 'cancel' })
-  expect(await FileWriter.fromPrompt({}, client)).toEqual(undefined)
+  expect(await fromPrompt({}, client)).toEqual(undefined)
 })
 
 test('creating from prompt succeeds', async () => {
   const client = fakeClient()
   client.promptToSave.mockResolvedValueOnce({ type: 'file', fd: 42 })
-  expect(await FileWriter.fromPrompt({}, client)).toBeInstanceOf(FileWriter)
+  expect(await fromPrompt({}, client)).toEqual({
+    write: expect.any(Function),
+    end: expect.any(Function),
+  })
 })
 
 test('write passes the file descriptor and data', async () => {
   const client = fakeClient()
-  const writer = new FileWriter(21, client)
+  const writer = create(21, client)
   await writer.write('abcdefg')
   expect(client.write).toHaveBeenCalledWith(21, 'abcdefg')
 })
 
 test('end passes the file descriptor', async () => {
   const client = fakeClient()
-  const writer = new FileWriter(21, client)
+  const writer = create(21, client)
   await writer.end()
   expect(client.end).toHaveBeenCalledWith(21)
 })

--- a/src/utils/FileWriter.test.ts
+++ b/src/utils/FileWriter.test.ts
@@ -4,7 +4,7 @@ import FileWriter from './FileWriter'
 
 function fakeClient(): jest.Mocked<Client> {
   const { ipcRenderer } = fakeIpc()
-  const client = new Client(ipcRenderer.invoke.bind(ipcRenderer))
+  const client = new Client(ipcRenderer)
 
   jest.spyOn(client, 'promptToSave').mockResolvedValue({ type: 'cancel' })
   jest.spyOn(client, 'write').mockResolvedValue(undefined)

--- a/src/utils/FileWriter.test.ts
+++ b/src/utils/FileWriter.test.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid'
 import { fakeIpc } from '../../test/ipc'
 import { Client } from '../ipc/saveAs'
 import { create, fromPrompt } from './FileWriter'
@@ -21,7 +22,7 @@ test('creating from prompt fails', async () => {
 
 test('creating from prompt succeeds', async () => {
   const client = fakeClient()
-  client.promptToSave.mockResolvedValueOnce({ type: 'file', fd: 42 })
+  client.promptToSave.mockResolvedValueOnce({ type: 'file', fd: uuid() })
   expect(await fromPrompt({}, client)).toEqual({
     write: expect.any(Function),
     end: expect.any(Function),
@@ -29,15 +30,17 @@ test('creating from prompt succeeds', async () => {
 })
 
 test('write passes the file descriptor and data', async () => {
+  const fd = uuid()
   const client = fakeClient()
-  const writer = create(21, client)
+  const writer = create(fd, client)
   await writer.write('abcdefg')
-  expect(client.write).toHaveBeenCalledWith(21, 'abcdefg')
+  expect(client.write).toHaveBeenCalledWith(fd, 'abcdefg')
 })
 
 test('end passes the file descriptor', async () => {
+  const fd = uuid()
   const client = fakeClient()
-  const writer = create(21, client)
+  const writer = create(fd, client)
   await writer.end()
-  expect(client.end).toHaveBeenCalledWith(21)
+  expect(client.end).toHaveBeenCalledWith(fd)
 })

--- a/src/utils/FileWriter.ts
+++ b/src/utils/FileWriter.ts
@@ -12,7 +12,7 @@ export interface FileWriter {
 /**
  * Create a file writer from the given file descriptor and client.
  */
-export function create(fd: number, client = new FileWriteClient()): FileWriter {
+export function create(fd: string, client = new FileWriteClient()): FileWriter {
   return {
     write: (data): Promise<void> => client.write(fd, data),
     end: (): Promise<void> => client.end(fd),

--- a/src/utils/FileWriter.ts
+++ b/src/utils/FileWriter.ts
@@ -1,53 +1,47 @@
-import { Client as SaveAsClient, PromptToSaveOptions } from '../ipc/saveAs'
 import { Client as FileWriteClient, Write } from '../ipc/file-system-write-file'
+import { Client as SaveAsClient, PromptToSaveOptions } from '../ipc/saveAs'
 
 /**
- * Simple wrapper class to handle writing data to file from a save dialog.
+ * Handles writing data to files.
  */
-export default class FileWriter {
-  public constructor(
-    private fd: number,
-    private client = new FileWriteClient(),
-  ) {}
+export interface FileWriter {
+  write(data: Write['data']): Promise<void>
+  end(): Promise<void>
+}
 
-  /**
-   * Write data to the file.
-   */
-  public async write(data: Write['data']): Promise<void> {
-    return await this.client.write(this.fd, data)
+/**
+ * Create a file writer from the given file descriptor and client.
+ */
+export function create(fd: number, client = new FileWriteClient()): FileWriter {
+  return {
+    write: (data): Promise<void> => client.write(fd, data),
+    end: (): Promise<void> => client.end(fd),
+  }
+}
+
+/**
+ * Opens a file with the given path and returns a writer for it.
+ */
+export async function fromPath(
+  path: string,
+  client = new FileWriteClient(),
+): Promise<FileWriter> {
+  const { fd } = await client.open(path)
+  return create(fd, client)
+}
+
+/**
+ * Prompts the user to choose a file path to write a file to.
+ */
+export async function fromPrompt(
+  options?: PromptToSaveOptions,
+  client = new SaveAsClient(),
+): Promise<FileWriter | undefined> {
+  const output = await client.promptToSave(options)
+
+  if (output.type === 'cancel') {
+    return
   }
 
-  /**
-   * Ends writing and closes the file.
-   */
-  public async end(): Promise<void> {
-    return await this.client.end(this.fd)
-  }
-
-  /**
-   * Opens a file with the given path and returns a writer for it.
-   */
-  public static async fromPath(
-    path: string,
-    client = new FileWriteClient(),
-  ): Promise<FileWriter> {
-    const { fd } = await client.open(path)
-    return new FileWriter(fd, client)
-  }
-
-  /**
-   * Prompts the user to choose a file path to write a file to.
-   */
-  public static async fromPrompt(
-    options?: PromptToSaveOptions,
-    client = new SaveAsClient(),
-  ): Promise<FileWriter | undefined> {
-    const output = await client.promptToSave(options)
-
-    if (output.type === 'cancel') {
-      return
-    }
-
-    return new FileWriter(output.fd, client)
-  }
+  return create(output.fd, client)
 }

--- a/src/utils/FileWriter.ts
+++ b/src/utils/FileWriter.ts
@@ -1,10 +1,14 @@
-import { Client, PromptToSaveOptions, Write } from '../ipc/saveAs'
+import { Client as SaveAsClient, PromptToSaveOptions } from '../ipc/saveAs'
+import { Client as FileWriteClient, Write } from '../ipc/file-system-write-file'
 
 /**
  * Simple wrapper class to handle writing data to file from a save dialog.
  */
 export default class FileWriter {
-  public constructor(private fd: number, private client = new Client()) {}
+  public constructor(
+    private fd: number,
+    private client = new FileWriteClient(),
+  ) {}
 
   /**
    * Write data to the file.
@@ -21,11 +25,22 @@ export default class FileWriter {
   }
 
   /**
+   * Opens a file with the given path and returns a writer for it.
+   */
+  public static async fromPath(
+    path: string,
+    client = new FileWriteClient(),
+  ): Promise<FileWriter> {
+    const { fd } = await client.open(path)
+    return new FileWriter(fd, client)
+  }
+
+  /**
    * Prompts the user to choose a file path to write a file to.
    */
   public static async fromPrompt(
     options?: PromptToSaveOptions,
-    client = new Client(),
+    client = new SaveAsClient(),
   ): Promise<FileWriter | undefined> {
     const output = await client.promptToSave(options)
 

--- a/src/utils/access.test.ts
+++ b/src/utils/access.test.ts
@@ -1,57 +1,63 @@
-import { hasReadAccess, hasWriteAccess, HostFilePermission } from './access'
+import { hasReadAccess, hasWriteAccess, OriginFilePermission } from './access'
 
 test('no permissions', () => {
-  const permissions: HostFilePermission[] = []
-  expect(hasReadAccess(permissions, 'localhost')).toBe(false)
-  expect(hasWriteAccess(permissions, 'localhost')).toBe(false)
+  const permissions: OriginFilePermission[] = []
+  expect(hasReadAccess(permissions, 'http://localhost:*')).toBe(false)
+  expect(hasWriteAccess(permissions, 'http://localhost:*')).toBe(false)
 })
 
 test('read-only permissions', () => {
-  const permissions: HostFilePermission[] = [
-    { hostnames: 'localhost', paths: '**/*', access: 'ro' },
+  const permissions: OriginFilePermission[] = [
+    { origins: 'http://localhost:*', paths: '**/*', access: 'ro' },
   ]
 
-  // matching hostname
-  expect(hasReadAccess(permissions, 'localhost')).toBe(true)
-  expect(hasWriteAccess(permissions, 'localhost')).toBe(false)
+  // matching origin
+  expect(hasReadAccess(permissions, 'http://localhost:*')).toBe(true)
+  expect(hasWriteAccess(permissions, 'http://localhost:*')).toBe(false)
 
-  // mismatching hostname
+  // mismatching origin
   expect(hasReadAccess(permissions, 'evil.com')).toBe(false)
   expect(hasWriteAccess(permissions, 'evil.com')).toBe(false)
 })
 
 test('write-only permissions', () => {
-  const permissions: HostFilePermission[] = [
-    { hostnames: 'localhost', paths: '**/*', access: 'wo' },
+  const permissions: OriginFilePermission[] = [
+    { origins: 'http://localhost:*', paths: '**/*', access: 'wo' },
   ]
 
-  // matching hostname
-  expect(hasReadAccess(permissions, 'localhost')).toBe(false)
-  expect(hasWriteAccess(permissions, 'localhost')).toBe(true)
+  // matching origin
+  expect(hasReadAccess(permissions, 'http://localhost:*')).toBe(false)
+  expect(hasWriteAccess(permissions, 'http://localhost:*')).toBe(true)
 
-  // mismatching hostname
-  expect(hasReadAccess(permissions, 'evil.com')).toBe(false)
-  expect(hasWriteAccess(permissions, 'evil.com')).toBe(false)
+  // mismatching origin
+  expect(hasReadAccess(permissions, 'http://evil.com')).toBe(false)
+  expect(hasWriteAccess(permissions, 'http://evil.com')).toBe(false)
 })
 
 test('read-write permissions', () => {
-  const permissions: HostFilePermission[] = [
-    { hostnames: 'localhost', paths: '**/*', access: 'rw' },
+  const permissions: OriginFilePermission[] = [
+    { origins: 'http://localhost:*', paths: '**/*', access: 'rw' },
   ]
 
-  // matching hostname
-  expect(hasReadAccess(permissions, 'localhost')).toBe(true)
-  expect(hasWriteAccess(permissions, 'localhost')).toBe(true)
+  // matching origin
+  expect(hasReadAccess(permissions, 'http://localhost:3000')).toBe(true)
+  expect(hasWriteAccess(permissions, 'http://localhost:3000')).toBe(true)
+  expect(hasReadAccess(permissions, 'http://localhost:3001')).toBe(true)
+  expect(hasWriteAccess(permissions, 'http://localhost:3001')).toBe(true)
 
   // mismatching hostname
-  expect(hasReadAccess(permissions, 'evil.com')).toBe(false)
-  expect(hasWriteAccess(permissions, 'evil.com')).toBe(false)
+  expect(hasReadAccess(permissions, 'http://evil.com')).toBe(false)
+  expect(hasWriteAccess(permissions, 'http://evil.com')).toBe(false)
+
+  // mismatching scheme
+  expect(hasReadAccess(permissions, 'https://localhost:3000')).toBe(false)
+  expect(hasWriteAccess(permissions, 'https://localhost:3000')).toBe(false)
 })
 
 test('permission order', () => {
-  const permissions: HostFilePermission[] = [
-    { hostnames: 'localhost', paths: '/media/**/*', access: 'ro' },
-    { hostnames: 'localhost', paths: '/media/usb-stick/**/*', access: 'rw' },
+  const permissions: OriginFilePermission[] = [
+    { origins: 'localhost', paths: '/media/**/*', access: 'ro' },
+    { origins: 'localhost', paths: '/media/usb-stick/**/*', access: 'rw' },
   ]
 
   // Both permissions grant read access, so this is clear.

--- a/src/utils/access.ts
+++ b/src/utils/access.ts
@@ -43,6 +43,19 @@ export function hasReadAccess(
 }
 
 /**
+ * Asserts that a host has read access, optionally to a specific path.
+ */
+export function assertHasReadAccess(
+  permissions: readonly HostFilePermission[],
+  hostname: string,
+  path?: string,
+): void {
+  if (!hasReadAccess(permissions, hostname, path)) {
+    throw new Error(`${hostname} is not allowed to read ${path ?? 'anything'}`)
+  }
+}
+
+/**
  * Determines whether a host write access granted by a list of permissions,
  * optionally considering a specific path.
  */
@@ -52,6 +65,19 @@ export function hasWriteAccess(
   path?: string,
 ): boolean {
   return hasAccess(permissions, hostname, path, 'wo', 'rw')
+}
+
+/**
+ * Asserts that a host has write access, optionally to a specific path.
+ */
+export function assertHasWriteAccess(
+  permissions: readonly HostFilePermission[],
+  hostname: string,
+  path?: string,
+): void {
+  if (!hasWriteAccess(permissions, hostname, path)) {
+    throw new Error(`${hostname} is not allowed to write to ${path ?? 'disk'}`)
+  }
 }
 
 function matchesPatterns(value: string, pattern: string): boolean {

--- a/src/utils/access.ts
+++ b/src/utils/access.ts
@@ -2,25 +2,25 @@ import multimatch from 'multimatch'
 
 export type AccessType = 'ro' | 'wo' | 'rw'
 
-export interface HostFilePermission {
+export interface OriginFilePermission {
   readonly paths: string
-  readonly hostnames: string
+  readonly origins: string
   readonly access: AccessType
 }
 
 /**
- * Determines whether a host has one of the access types granted by a list of
+ * Determines whether an origin has one of the access types granted by a list of
  * permissions, optionally considering a specific path.
  */
 export function hasAccess(
-  permissions: readonly HostFilePermission[],
-  hostname: string,
+  permissions: readonly OriginFilePermission[],
+  origin: string,
   path?: string,
   ...accesses: AccessType[]
 ): boolean {
-  for (const { hostnames, paths, access } of permissions) {
+  for (const { origins, paths, access } of permissions) {
     if (
-      matchesPatterns(hostname, hostnames) &&
+      matchesPatterns(origin, origins) &&
       (!path || matchesPatterns(path, paths))
     ) {
       return accesses.includes(access)
@@ -31,52 +31,52 @@ export function hasAccess(
 }
 
 /**
- * Determines whether a host read access granted by a list of permissions,
- * optionally considering a specific path.
+ * Determines whether an origin has read access granted by a list of
+ * permissions, optionally considering a specific path.
  */
 export function hasReadAccess(
-  permissions: readonly HostFilePermission[],
-  hostname: string,
+  permissions: readonly OriginFilePermission[],
+  origin: string,
   path?: string,
 ): boolean {
-  return hasAccess(permissions, hostname, path, 'ro', 'rw')
+  return hasAccess(permissions, origin, path, 'ro', 'rw')
 }
 
 /**
- * Asserts that a host has read access, optionally to a specific path.
+ * Asserts that an origin has read access, optionally to a specific path.
  */
 export function assertHasReadAccess(
-  permissions: readonly HostFilePermission[],
-  hostname: string,
+  permissions: readonly OriginFilePermission[],
+  origin: string,
   path?: string,
 ): void {
-  if (!hasReadAccess(permissions, hostname, path)) {
-    throw new Error(`${hostname} is not allowed to read ${path ?? 'anything'}`)
+  if (!hasReadAccess(permissions, origin, path)) {
+    throw new Error(`${origin} is not allowed to read ${path ?? 'anything'}`)
   }
 }
 
 /**
- * Determines whether a host write access granted by a list of permissions,
- * optionally considering a specific path.
+ * Determines whether an origin has write access granted by a list of
+ * permissions, optionally considering a specific path.
  */
 export function hasWriteAccess(
-  permissions: readonly HostFilePermission[],
-  hostname: string,
+  permissions: readonly OriginFilePermission[],
+  origin: string,
   path?: string,
 ): boolean {
-  return hasAccess(permissions, hostname, path, 'wo', 'rw')
+  return hasAccess(permissions, origin, path, 'wo', 'rw')
 }
 
 /**
- * Asserts that a host has write access, optionally to a specific path.
+ * Asserts that an origin has write access, optionally to a specific path.
  */
 export function assertHasWriteAccess(
-  permissions: readonly HostFilePermission[],
-  hostname: string,
+  permissions: readonly OriginFilePermission[],
+  origin: string,
   path?: string,
 ): void {
-  if (!hasWriteAccess(permissions, hostname, path)) {
-    throw new Error(`${hostname} is not allowed to write to ${path ?? 'disk'}`)
+  if (!hasWriteAccess(permissions, origin, path)) {
+    throw new Error(`${origin} is not allowed to write to ${path ?? 'disk'}`)
   }
 }
 

--- a/src/utils/access.ts
+++ b/src/utils/access.ts
@@ -1,4 +1,7 @@
 import multimatch from 'multimatch'
+import makeDebug from 'debug'
+
+const debug = makeDebug('kiosk-browser:access')
 
 export type AccessType = 'ro' | 'wo' | 'rw'
 
@@ -18,16 +21,28 @@ export function hasAccess(
   path?: string,
   ...accesses: AccessType[]
 ): boolean {
+  let result = false
+
   for (const { origins, paths, access } of permissions) {
     if (
       matchesPatterns(origin, origins) &&
       (!path || matchesPatterns(path, paths))
     ) {
-      return accesses.includes(access)
+      result = accesses.includes(access)
+      break
     }
   }
 
-  return false
+  debug(
+    'ACCESS %s: origin=%s, path=%s, accesses=%o, permissions=%o',
+    result ? 'ALLOWED' : 'DENIED',
+    origin,
+    path,
+    accesses,
+    permissions,
+  )
+
+  return result
 }
 
 /**

--- a/src/utils/options.test.ts
+++ b/src/utils/options.test.ts
@@ -12,22 +12,22 @@ async function parseOptionsWithoutHelp(
 }
 
 test('returns the first argument URL if it can be parsed as a URL', async () => {
-  const options = await parseOptionsWithoutHelp(['http://example.com/'])
-  expect(options.url.href).toEqual('http://example.com/')
+  const options = await parseOptionsWithoutHelp(['https://example.com/'])
+  expect(options.url.href).toEqual('https://example.com/')
 })
 
 test('returns the value of KIOSK_BROWSER_URL if it can be parsed as a URL', async () => {
   const options = await parseOptionsWithoutHelp([], {
-    KIOSK_BROWSER_URL: 'http://example.com/',
+    KIOSK_BROWSER_URL: 'https://example.com/',
   })
-  expect(options.url.href).toEqual('http://example.com/')
+  expect(options.url.href).toEqual('https://example.com/')
 })
 
 test('prefers the argument URL to the environment URL', async () => {
-  const options = await parseOptionsWithoutHelp(['http://example.com/argv'], {
-    KIOSK_BROWSER_URL: 'http://example.com/env',
+  const options = await parseOptionsWithoutHelp(['https://example.com/argv'], {
+    KIOSK_BROWSER_URL: 'https://example.com/env',
   })
-  expect(options.url.href).toEqual('http://example.com/argv')
+  expect(options.url.href).toEqual('https://example.com/argv')
 })
 
 test('falls back to about:blank if nothing else is given', async () => {
@@ -57,33 +57,33 @@ test('allow devtools', async () => {
   )
 })
 
-test('file permission with default hostname and access', async () => {
+test('file permission with default origin and access', async () => {
   const options = await parseOptionsWithoutHelp([
     '--add-file-perm',
-    '/media/**/*',
+    'p=/media/**/*',
   ])
-  expect(options.hostFilePermissions).toEqual([
-    { hostnames: '*', paths: '/media/**/*', access: 'rw' },
+  expect(options.originFilePermissions).toEqual([
+    { origins: '**/*', paths: '/media/**/*', access: 'rw' },
   ])
 })
 
 test('file permission with default access', async () => {
   const options = await parseOptionsWithoutHelp([
     '--add-file-perm',
-    'localhost:/media/**/*',
+    'o=http://localhost,p=/media/**/*',
   ])
-  expect(options.hostFilePermissions).toEqual([
-    { hostnames: 'localhost', paths: '/media/**/*', access: 'rw' },
+  expect(options.originFilePermissions).toEqual([
+    { origins: 'http://localhost', paths: '/media/**/*', access: 'rw' },
   ])
 })
 
 test('file permission', async () => {
   const options = await parseOptionsWithoutHelp([
     '--add-file-perm',
-    'localhost:/media/**/*:ro',
+    'o=http://localhost:*,p=/media/**/*,ro',
   ])
-  expect(options.hostFilePermissions).toEqual([
-    { hostnames: 'localhost', paths: '/media/**/*', access: 'ro' },
+  expect(options.originFilePermissions).toEqual([
+    { origins: 'http://localhost:*', paths: '/media/**/*', access: 'ro' },
   ])
 })
 

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -3,7 +3,7 @@ import { Device } from 'usb-detection'
 import { BatteryInfo } from '../src/ipc/get-battery-info'
 import { PrinterInfo } from '../src/ipc/get-printer-info'
 import { PromptToSaveOptions } from '../src/ipc/saveAs'
-import FileWriter from '../src/utils/FileWriter'
+import { FileWriter } from '../src/utils/FileWriter'
 
 declare namespace KioskBrowser {
   interface PrintOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,6 +734,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"


### PR DESCRIPTION
These APIs build on the expanded file access permissions introduced in https://github.com/votingworks/kiosk-browser/pull/61. There are APIs for reading files, writing files, and reading the contents of a directory. These will allow building a custom file load/save interface if desired, though it wouldn't have all the features that might be desired such as creating folders or renaming files.

<img width="474" alt="Untitled 2" src="https://user-images.githubusercontent.com/1938/97496980-07c98b80-1927-11eb-81d7-e3dc8f0cd6ef.png">
