### PR TITLE
fix: propagate stderr from `setClock` on failure

### DIFF
--- a/src/ipc/clock.test.ts
+++ b/src/ipc/clock.test.ts
@@ -55,3 +55,18 @@ test('set datetime works in non- daylights savings', async () => {
     'America/Chicago',
   ])
 })
+
+test('set datetime fails when NTP is enabled', async () => {
+  execMock.mockRejectedValueOnce(
+    new Error('Failed to set time: Automatic time synchronization is enabled'),
+  )
+
+  await expect(
+    ipcRenderer.invoke(setClockChannel, {
+      isoDatetime: '2020-11-03T15:00Z',
+      IANAZone: 'America/Chicago',
+    }),
+  ).rejects.toThrowError(
+    'Failed to set time: Automatic time synchronization is enabled',
+  )
+})

--- a/src/ipc/clock.ts
+++ b/src/ipc/clock.ts
@@ -20,7 +20,15 @@ export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(
     channel,
     async (event: IpcMainInvokeEvent, params: KioskBrowser.SetClockParams) => {
-      await clockSet(params)
+      try {
+        await clockSet(params)
+      } catch (error) {
+        if ('stderr' in error) {
+          throw new Error(error.stderr)
+        } else {
+          throw error
+        }
+      }
     },
   )
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -57,7 +57,7 @@ export default async function exec(
             signal,
             stdout,
             stderr,
-            cmd: file,
+            cmd: `${file} ${args.join(' ')}`,
           }),
         )
       }
@@ -83,7 +83,7 @@ export function makeExecError({
   cmd = '',
 }: Partial<ExecError> = {}): ExecError & Error {
   const error = (new Error(
-    `Error: Command failed: ${cmd}`,
+    `Error: Command failed: ${cmd} (stdout=${stdout} stderr=${stderr})`,
   ) as unknown) as ExecError & Error
 
   Object.defineProperties(error, {


### PR DESCRIPTION
Now trying to set the clock while NTP is on will yield this sensible error message:

<img width="705" alt="Untitled" src="https://user-images.githubusercontent.com/1938/98849460-1a07f700-2408-11eb-93b9-3c5ff28b5e57.png">
