### PR TITLE
Add missing uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "multimatch": "^4.0.0",
     "rxjs": "^6.5.4",
     "usb-detection": "^4.7.0",
+    "uuid": "^8.3.1",
     "xrandr-parse": "^1.0.0",
     "zod": "^1.10.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6400,6 +6400,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
Noticed this dependency was missing when testing building/running the current main branch of kiosk-browser from vx-complete-system