### PR TITLE
fix: set datetime & timezone correctly

### DIFF
--- a/src/ipc/clock.test.ts
+++ b/src/ipc/clock.test.ts
@@ -23,15 +23,15 @@ test('set datetime works in daylights savings', async () => {
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     '/usr/bin/timedatectl',
-    'set-time',
-    '2020-10-03 10:00:00',
+    'set-timezone',
+    'America/Chicago',
   ])
 
   expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     '/usr/bin/timedatectl',
-    'set-timezone',
-    'America/Chicago',
+    'set-time',
+    '2020-10-03 10:00:00',
   ])
 })
 
@@ -44,15 +44,15 @@ test('set datetime works in non- daylights savings', async () => {
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     '/usr/bin/timedatectl',
-    'set-time',
-    '2020-11-03 09:00:00',
+    'set-timezone',
+    'America/Chicago',
   ])
 
   expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     '/usr/bin/timedatectl',
-    'set-timezone',
-    'America/Chicago',
+    'set-time',
+    '2020-11-03 09:00:00',
   ])
 })
 

--- a/src/ipc/clock.ts
+++ b/src/ipc/clock.ts
@@ -12,8 +12,8 @@ async function clockSet({
   const datetimeString = DateTime.fromISO(isoDatetime, {
     zone: IANAZone,
   }).toFormat('yyyy-LL-dd TT')
-  await exec('sudo', ['-n', '/usr/bin/timedatectl', 'set-time', datetimeString])
   await exec('sudo', ['-n', '/usr/bin/timedatectl', 'set-timezone', IANAZone])
+  await exec('sudo', ['-n', '/usr/bin/timedatectl', 'set-time', datetimeString])
 }
 
 export default function register(ipcMain: IpcMain): void {


### PR DESCRIPTION
Setting the time first and then the timezone results in the wrong time being set when the timezone differs from the current system timezone. This is because setting the time to e.g. 12:00:00 when in Pacific Time and then setting the time zone to Eastern Time will update the time to 15:00:00.

Closes votingworks/vxsuite#410