### PR TITLE
fix(hardware): handle devices without batteries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Generic kiosk-mode browser.
 1. Install [NodeJS](https://nodejs.org/en/) and [Yarn](https://www.yarnpkg.com/en/).
 1. Install native package dependencies with `make install`.
 1. Build a Debian/Ubuntu package with `make build`.
-1. Copy `out/make/deb/x64/kiosk-browser_*_amd64.deb` wherever you want to install it (note wildcard).
-1. Install it with `sudo dpkg -i kiosk-browser_*_amd64.deb` (note wildcard).
+1. Copy `out/make/deb/x64/kiosk-browser_*.deb` wherever you want to install it (note wildcard).
+1. Install it with `sudo dpkg -i kiosk-browser_*.deb` (note wildcard).
 1. Run with the URL you want to visit as a CLI argument (e.g. `kiosk-browser https://example.com/`) or with an environment variable (e.g. `KIOSK_BROWSER_URL=https://example.com/ kiosk-browser`).
 
 ## Kiosk Page API
 
 Web pages loaded by `kiosk-browser` have an extra API accessible via the global `kiosk` object.
 
-`kiosk.`**`getBatteryInfo`**`(): Promise<{ level: number, discharging: boolean }>`
+`kiosk.`**`getBatteryInfo`**`(): Promise<{ level: number, discharging: boolean } | undefined>`
 
 Gets an object describing the current state of the battery, including level and discharging status.
 

--- a/src/ipc/get-battery-info.test.ts
+++ b/src/ipc/get-battery-info.test.ts
@@ -102,10 +102,9 @@ POWER_SUPPLY_STATUS=Discharging
   )
 })
 
-test('fails to read battery info if the power_supply "files" are not present', async () => {
+test('returns undefined if the power_supply "files" are not present', async () => {
   jest.spyOn(fs, 'readFile').mockRejectedValue(new Error('ENOENT'))
-
-  await expect(getBatteryInfo()).rejects.toThrowError('No batteries found')
+  expect(await getBatteryInfo()).toBeUndefined()
 })
 
 test('registers a handler to get battery info', async () => {

--- a/src/ipc/get-battery-info.ts
+++ b/src/ipc/get-battery-info.ts
@@ -19,7 +19,7 @@ export const channel = 'get-battery-info'
 /**
  * Get battery info for the main system battery.
  */
-export async function getBatteryInfo(): Promise<BatteryInfo> {
+export async function getBatteryInfo(): Promise<BatteryInfo | undefined> {
   for (const batteryPath of ['BAT0', 'BAT1']) {
     try {
       return parseBatteryInfo(
@@ -32,10 +32,6 @@ export async function getBatteryInfo(): Promise<BatteryInfo> {
       // ignore missing paths
     }
   }
-
-  throw new Error(
-    'No batteries found; perhaps /sys/class/power_supply is not available?',
-  )
 }
 
 /**

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -83,7 +83,7 @@ class Kiosk implements KioskBrowser.Kiosk {
     return await ipcRenderer.invoke(printToPDFChannel)
   }
 
-  public async getBatteryInfo(): Promise<BatteryInfo> {
+  public async getBatteryInfo(): Promise<BatteryInfo | undefined> {
     debug('forwarding `getBatteryInfo` to main process')
     return ipcRenderer.invoke(getBatteryInfoChannel)
   }

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -38,7 +38,7 @@ declare namespace KioskBrowser {
     | 'two-sided-short-edge'
 
   interface Kiosk {
-    getBatteryInfo(): Promise<BatteryInfo>
+    getBatteryInfo(): Promise<BatteryInfo | undefined>
     getPrinterInfo(): Promise<PrinterInfo[]>
     devices: Observable<Iterable<Device>>
     print(options?: KioskBrowser.PrintOptions): Promise<void>


### PR DESCRIPTION
In production all our devices have batteries, but this may not always be true. In addition, running in development on a desktop means there will be no batteries. Frontends will now check that there is a battery before trying to check its status.

Refs https://github.com/votingworks/vxsuite/pull/1289