### PR TITLE
fix(kiosk) add retries when connecting printer

### DIFF
--- a/src/ipc/get-printer-info.test.ts
+++ b/src/ipc/get-printer-info.test.ts
@@ -30,7 +30,7 @@ describe('getPrinterInfo', () => {
   })
 
   it('expands the printer info with connected=false if lpinfo does not show the device', async () => {
-    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(new Set())
+    mockOf(getConnectedDeviceURIs).mockResolvedValue(new Set())
 
     expect(
       await getPrinterInfo([
@@ -39,6 +39,25 @@ describe('getPrinterInfo', () => {
         }),
       ]),
     ).toEqual([expect.objectContaining({ connected: false })])
+  })
+
+  it('expands the printer info with connected=true if lpinfo shows the device after a momentary blip', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(new Set())
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
+      new Set(['usb://HP/Color%20LaserJet?serial=1234']),
+    )
+
+    expect(
+      await getPrinterInfo([
+        fakePrinter(),
+        fakePrinter({
+          options: { 'device-uri': 'usb://HP/Color%20LaserJet?serial=1234' },
+        }),
+      ]),
+    ).toEqual([
+      expect.objectContaining({ connected: false }),
+      expect.objectContaining({ connected: true }),
+    ])
   })
 })
 


### PR DESCRIPTION
I'm not sure that this is the right long term strategy but I believe should mitigate the printer not connected issue for now. The issue is when getting the connected device URI's it sometimes does not have the printer yet causing it to fail. This adds some retries when there is no printer connected. I only make it retry twice as the issue is so rare I think this should be sufficient but I plan to leave this running overnight to make sure it never happens. In practice 1 retry has always solved it in my (admittedly limited) testing. 

Note: This does cause the new-device-attached logs that happen here: https://github.com/votingworks/vxsuite/blob/main/libs/ui/src/hooks/use_hardware.ts#L139 to all print an extra time when the retry occurs, I'm not sure if that is potentially problematic. 

https://github.com/votingworks/vxsuite/issues/1303