### PR TITLE
Install cups on debian

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -13,7 +13,7 @@ fi
 $SUDO apt-get install -y build-essential libudev-dev unzip git python pmount cups-client
 
 if [[ $OS == "bullseye" ]]; then
-	sudo apt install -y libgtk-3-0  libnotify4 libxss1 libxtst6 xdg-utils libatspi2.0-0 kde-cli-tools trash-cli libglib2.0-bin gvfs-bin
+	sudo apt install -y libgtk-3-0  libnotify4 libxss1 libxtst6 xdg-utils libatspi2.0-0 kde-cli-tools trash-cli libglib2.0-bin gvfs-bin cups
 fi
 
 if ! command -v node >/dev/null 2>&1; then


### PR DESCRIPTION
@umbernhard is adding this to the setup-machine script in vxsuite-complete-system but in order for kiosk-browser to run on debian in dev you need cups installed or lpinfo won't work. 