### PR TITLE
feat(kiosk) add reboot function to kiosk browser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import registerUnmountUsbDriveHandler from './ipc/unmount-usb-drive'
 import registerTotpGetHandler from './ipc/totp-get'
 import registerLogHandler from './ipc/log'
 import registerSignHandler from './ipc/sign'
+import registerRebootHandler from './ipc/reboot'
 import parseOptions, { Options, printHelp } from './utils/options'
 import autoconfigurePrint from './utils/printing/autoconfigurePrinter'
 import { getMainScreen } from './utils/screen'
@@ -121,6 +122,7 @@ async function createWindow(): Promise<void> {
     registerTotpGetHandler,
     registerLogHandler,
     registerSignHandler,
+    registerRebootHandler,
   ]
 
   const handlerCleanups = handlers

--- a/src/ipc/reboot.test.ts
+++ b/src/ipc/reboot.test.ts
@@ -1,0 +1,21 @@
+import { fakeIpc } from '../../test/ipc'
+import register, { channel } from './reboot'
+import mockOf from '../../test/mockOf'
+import exec from '../utils/exec'
+
+const execMock = mockOf(exec)
+jest.mock('../utils/exec')
+
+beforeEach(() => {
+  execMock.mockReset()
+  execMock.mockResolvedValue({ stdout: '', stderr: '' })
+})
+
+test('reboot', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc()
+
+  register(ipcMain)
+
+  await ipcRenderer.invoke(channel)
+  expect(execMock).toHaveBeenCalledTimes(1)
+})

--- a/src/ipc/reboot.ts
+++ b/src/ipc/reboot.ts
@@ -1,0 +1,13 @@
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import exec from '../utils/exec'
+
+export const channel = 'reboot'
+
+/**
+ * Reboot the machine
+ */
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(channel, async (event: IpcMainInvokeEvent) => {
+    await exec('reboot')
+  })
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -35,6 +35,7 @@ import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive'
 import { channel as totpGetChannel, TotpInfo } from './ipc/totp-get'
 import { channel as signChannel, SignParams } from './ipc/sign'
 import { channel as logChannel } from './ipc/log'
+import { channel as rebootChannel } from './ipc/reboot'
 import buildDevicesObservable from './utils/buildDevicesObservable'
 import buildPrinterInfoObservable from './utils/buildPrinterInfoObservable'
 import { FileWriter, fromPath, fromPrompt } from './utils/FileWriter'
@@ -233,6 +234,11 @@ class Kiosk implements KioskBrowser.Kiosk {
   public quit(): void {
     debug('forwarding `quit` to main process')
     ipcRenderer.invoke(quitChannel)
+  }
+
+  public async reboot(): Promise<void> {
+    debug('forwarding `reboot` to the main process')
+    return await ipcRenderer.invoke(rebootChannel)
   }
 }
 


### PR DESCRIPTION
We will need this for https://github.com/votingworks/vxsuite/issues/1401 so adding it as a first step. 

I'm imagining having separate functions to change the boot order, see if the USB drive is available to be put in the boot order, and actually reboot, so that we can show on the frontend what step we're on and since we will sometimes reboot without changing the boot order (if the usb drive isn't available in efibootmgr yet) and sometimes after changing the boot order. 

Is there any way we should be checking permissions at the kiosk-browser level? To make sure that you have to be a superadmin to do change the boot order?