### PR TITLE
feat(kiosk) add prepare to boot from usb function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ If you're working on a bug fix or feature for `kiosk-browser`, here's how to bui
 1. Install native package dependencies with `make install`.
 1. Run with `yarn start`. Changes will not automatically be picked up, so just Ctrl-C the `yarn start` and run it again.
 
+Kiosk browser has a number of command line arguments if you want the permissions and print config to mimic production but have access to devtools you probably want to run `kiosk-browser` locally with the following command:
+
+```sh
+DEBUG=kiosk-browser:* DISPLAY=:0 KIOSK_BROWSER_ALLOW_DEVTOOLS=true KIOSK_BROWSER_URL=http://localhost:3000/ KIOSK_BROWSER_FILE_PERMISSIONS='o=http://localhost:3000,p=/**/*,rw' KIOSK_BROWSER_AUTOCONFIGURE_PRINT_CONFIG=../vxsuite-complete-system/printing/printer-autoconfigure.json yarn start
+```
+
 ## License
 
 GPL-3.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import registerTotpGetHandler from './ipc/totp-get'
 import registerLogHandler from './ipc/log'
 import registerSignHandler from './ipc/sign'
 import registerRebootHandler from './ipc/reboot'
+import registerPrepareBootUsb from './ipc/prepare-boot-usb'
 import parseOptions, { Options, printHelp } from './utils/options'
 import autoconfigurePrint from './utils/printing/autoconfigurePrinter'
 import { getMainScreen } from './utils/screen'
@@ -123,6 +124,7 @@ async function createWindow(): Promise<void> {
     registerLogHandler,
     registerSignHandler,
     registerRebootHandler,
+    registerPrepareBootUsb,
   ]
 
   const handlerCleanups = handlers

--- a/src/ipc/prepare-boot-usb.test.ts
+++ b/src/ipc/prepare-boot-usb.test.ts
@@ -1,0 +1,131 @@
+import { fakeIpc } from '../../test/ipc'
+import mockOf from '../../test/mockOf'
+import exec from '../utils/exec'
+import register, { channel } from './prepare-boot-usb'
+
+const execMock = mockOf(exec)
+
+jest.mock('../utils/exec')
+
+test('prepare-boot-usb returns false when no bootable usbs', async () => {
+  // Register our handler.
+  const { ipcMain, ipcRenderer } = fakeIpc()
+  register(ipcMain)
+
+  // Things should be registered as expected.
+  execMock.mockResolvedValueOnce({
+    stdout: `BootCurrent: 0005
+Timeout: 0 seconds
+BootOrder: 0005,0002,0001,0003,0000,0004
+Boot0000* UiApp	FvVol(45801e53-5502-4463-929a-9bafaf424a72)/FvFile(462caa21-7614-4503-836e-8ab6f4662331)
+Boot0001* UEFI Virtual DVD-ROM 	VenHw(0d51905b-b77e-452a-a2c0-eca0cc8d514a,000014020000000000)/Sata(1,65535,0)N.....YM....R,Y.
+Boot0002* UEFI My Amazing VM-0 SSD VV1P025T47V454YQW0DW	VenHw(0d51905b-b77e-452a-a2c0-eca0cc8d514a,000014020000000000)/Sata(0,65535,0)N.....YM....R,Y.
+Boot0003* No OS found	FvVol(45801e53-5502-4463-929a-9bafaf424a72)/FvFile(343e8cc7-cbc7-4d2f-af94-e783b827053b)
+Boot0004* UEFI Shell	FvVol(45801e53-5502-4463-929a-9bafaf424a72)/FvFile(7c04a583-9e3e-4f1c-ad65-e05268d0b4d1)
+Boot0005* debian	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/File(\\EFI\\debian\\shimaa64.efi)
+    `,
+    stderr: '',
+  })
+  execMock.mockResolvedValueOnce({
+    stdout: '{"blockdevices": [{"name": "sda1", "partuuid":"7dd453ac-01"}]}',
+    stderr: '',
+  })
+
+  // Is the handler wired up right?
+  const result = await ipcRenderer.invoke(channel)
+  expect(result).toBe(false)
+
+  expect(execMock).toBeCalledTimes(2)
+  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v'])
+  expect(execMock).toHaveBeenNthCalledWith(2, 'lsblk', [
+    '-o',
+    'partuuid,name',
+    '-J',
+    '-l',
+  ])
+})
+
+test('prepare-boot-usb returns false when there are more than one bootable usbs', async () => {
+  // Register our handler.
+  const { ipcMain, ipcRenderer } = fakeIpc()
+  register(ipcMain)
+
+  // Things should be registered as expected.
+  execMock.mockResolvedValueOnce({
+    stdout: `BootCurrent: 0000
+Timeout: 0 seconds
+BootOrder: 0000
+Boot0000* ubuntu	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/File(somefile.efi)
+Boot0001* Linpus Lite	HD(1,MDR,0x314d08f,0x800,0x100000)/File(\\EFI\\boot\\grubx64.efi)RC
+Boot0002* Linpus Lite	HD(1,MDR,0x123d08f,0x800,0x100000)/File(\\EFI\\boot\\grubx64.efi)RC
+Boot2001* EFI USB Device	RC
+Boot2002* EFI DVD/CDROM	RC
+Boot2003* EFI Network	RC
+       `,
+    stderr: '',
+  })
+  execMock.mockResolvedValueOnce({
+    stdout:
+      '{"blockdevices": [{"name": "sda1", "partuuid":"123d08f-01"}, {"name": "sdb1", "partuuid":"314d08f-01"}]}',
+    stderr: '',
+  })
+
+  // Is the handler wired up right?
+  const result = await ipcRenderer.invoke(channel)
+  expect(result).toBe(false)
+
+  expect(execMock).toBeCalledTimes(2)
+  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v'])
+  expect(execMock).toHaveBeenNthCalledWith(2, 'lsblk', [
+    '-o',
+    'partuuid,name',
+    '-J',
+    '-l',
+  ])
+})
+
+test('prepare-boot-usb returns true when expected and sets correct boot order', async () => {
+  // Register our handler.
+  const { ipcMain, ipcRenderer } = fakeIpc()
+  register(ipcMain)
+
+  // Things should be registered as expected.
+  execMock.mockResolvedValueOnce({
+    stdout: `BootCurrent: 0000
+Timeout: 0 seconds
+BootOrder: 0000
+Boot0000* ubuntu	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/File(somefile.efi)
+Boot0001* Linpus Lite	HD(1,MDR,0x314d08f,0x800,0x100000)/File(\\EFI\\boot\\grubx64.efi)RC
+Boot2001* EFI USB Device	RC
+Boot2002* EFI DVD/CDROM	RC
+Boot2003* EFI Network	RC
+       `,
+    stderr: '',
+  })
+  execMock.mockResolvedValueOnce({
+    stdout: '{"blockdevices": [{"name": "sda1", "partuuid":"314d08f-01"}]}',
+    stderr: '',
+  })
+  execMock.mockResolvedValueOnce({
+    stdout: '',
+    stderr: '',
+  })
+
+  // Is the handler wired up right?
+  const result = await ipcRenderer.invoke(channel, 'sdb1')
+  expect(result).toBe(true)
+  expect(execMock).toBeCalledTimes(3)
+  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v'])
+  expect(execMock).toHaveBeenNthCalledWith(2, 'lsblk', [
+    '-o',
+    'partuuid,name',
+    '-J',
+    '-l',
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', [
+    '-n',
+    '/bin/efibootmgr',
+    '-n',
+    '0001',
+  ])
+})

--- a/src/ipc/prepare-boot-usb.ts
+++ b/src/ipc/prepare-boot-usb.ts
@@ -1,0 +1,123 @@
+import makeDebug from 'debug'
+import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import exec from '../utils/exec'
+import { join } from 'path'
+
+export const channel = 'prepare-boot-usb'
+const debug = makeDebug('kiosk-browser:prepare-boot-usb')
+
+const BootableOptionPattern = /^Boot([0-9]+)\*\s(.+)\s(.+)$/
+const HardDriveDetailsPattern = /^HD\(.+,.+,(.+),.+,.+\).+$/
+const CurrentBootPattern = /^BootCurrent:\s*(.+)$/
+
+export interface BootOption {
+  bootNumber: string // The string representing the boot number i.e. `0001`
+  bootLabel: string // The label for the bootable device i.e. 'Linpus Lite'
+  partitionUUID?: string // For bootable hard drives, the partition UUID of the bootable partition.
+  isCurrentBoot: boolean
+}
+
+function parseEfiBootMgrOutput(output: string): BootOption[] {
+  const options: BootOption[] = []
+  const outputLines = output.split('\n')
+  let currentBootNumber = ''
+  for (const line of outputLines) {
+    if (!line) {
+      continue
+    }
+    const match = CurrentBootPattern.exec(line)
+    if (match) {
+      currentBootNumber = match.slice(1)[0]
+    }
+  }
+
+  for (const line of outputLines) {
+    if (!line) {
+      continue
+    }
+    const match = BootableOptionPattern.exec(line)
+
+    if (match) {
+      const [bootNumber, bootLabel, verboseDetails] = match.slice(1)
+      const partUUIDMatch = HardDriveDetailsPattern.exec(verboseDetails)
+      const partitionUUID = partUUIDMatch
+        ? partUUIDMatch.slice(1)[0]
+        : undefined
+      debug(
+        `Parsed bootable option with bootNumber: ${bootNumber} and label: ${bootLabel}`,
+      )
+      if (partitionUUID) {
+        debug(
+          `Bootable Device ${bootLabel} has partition UUID: ${partitionUUID}`,
+        )
+      }
+      options.push({
+        bootNumber,
+        bootLabel,
+        partitionUUID,
+        isCurrentBoot: currentBootNumber === bootNumber,
+      })
+    }
+  }
+  return options
+}
+
+/**
+ * Attempts to update set the boot manager to boot from a usb device. Returns true
+ * if successful, returns false if there are either 0 or more then 1 bootable usb drives available.
+ */
+async function prepareToBootFromUsb(): Promise<boolean> {
+  const { stdout: bootStdout } = await exec('efibootmgr', ['-v'])
+  const bootOptions = parseEfiBootMgrOutput(bootStdout)
+  const { stdout: lsblkStdout } = await exec('lsblk', [
+    '-o',
+    'partuuid,name',
+    '-J',
+    '-l',
+  ])
+  const rawData = JSON.parse(lsblkStdout)
+  let bootableUsbOption = undefined
+  for (const deviceInfo of rawData.blockdevices) {
+    if (deviceInfo.name.startsWith('sd') && deviceInfo.partuuid !== null) {
+      const matchingBootOption = bootOptions.find(
+        bootOption =>
+          !bootOption.isCurrentBoot &&
+          bootOption.partitionUUID === `0x${deviceInfo.partuuid.split('-')[0]}`,
+      )
+      if (matchingBootOption !== undefined) {
+        if (
+          bootableUsbOption !== undefined &&
+          bootableUsbOption !== matchingBootOption
+        ) {
+          // There are more then one bootable usb drives connected to the machine.
+          debug('More then one bootable usb device was found.')
+          return false
+        }
+        bootableUsbOption = matchingBootOption
+      }
+    }
+  }
+  if (bootableUsbOption === undefined) {
+    debug('No bootable usb device was found.')
+    return false
+  }
+  debug(
+    'The USB boot option was properly located setting it to be next in the boot order…',
+  )
+  await exec('sudo', [
+    '-n',
+    '/bin/efibootmgr',
+    '-n',
+    bootableUsbOption.bootNumber,
+  ])
+  return true
+}
+
+/**
+ * Registers a handler to set the boot order to boot from the given usb device next.
+ */
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(channel, async () => {
+    return await prepareToBootFromUsb()
+  })
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -36,6 +36,7 @@ import { channel as totpGetChannel, TotpInfo } from './ipc/totp-get'
 import { channel as signChannel, SignParams } from './ipc/sign'
 import { channel as logChannel } from './ipc/log'
 import { channel as rebootChannel } from './ipc/reboot'
+import { channel as prepareBootUsbChannel } from './ipc/prepare-boot-usb'
 import buildDevicesObservable from './utils/buildDevicesObservable'
 import buildPrinterInfoObservable from './utils/buildPrinterInfoObservable'
 import { FileWriter, fromPath, fromPrompt } from './utils/FileWriter'
@@ -201,6 +202,11 @@ class Kiosk implements KioskBrowser.Kiosk {
   public async sign(params: SignParams): Promise<string> {
     debug('forwarding `sign` to main process')
     return await ipcRenderer.invoke(signChannel, params)
+  }
+
+  public async prepareToBootFromUsb(): Promise<boolean> {
+    debug('forwarding `prepareToBootFromUsb` to main process')
+    return await ipcRenderer.invoke(prepareBootUsbChannel)
   }
 
   public async log(message: string): Promise<void> {


### PR DESCRIPTION
Adds a function to prepare the device to boot, on the next boot, from the bootable drive associated with the given usb device. I made it take the usb device name as an input but after testing on clonezilla I'm not 100% sure that makes the most sense so open to suggestions. 

Basically when the boot stick is clonezilla there are two partitions, they are different parts of the same "partition uuid" that efibootmgr cares about. For example. /dev/sda1 might map to the partition uuid "123456789-01" and /dev/sda2 would map to "123456789-02". `efibootmgr -v` will give the id `0x123456789` and just have one bootable entry so it will actually work regardless of whether you call the function with sda1 or sda2, as I am just ignoring the part of the uuid after the `-`. I'm not sure if it will be confusing on the frontend to decide which usb device to call the function with if more then one is mounted (like will be the case with clonezilla) although it doesn't actually matter. 

An alternative would be to not have an argument to this function, don't pass a path in to the call to `lsblk` and look for ANY entry from `lsblk` that has the same ID as any output in efibootmgr and then if there is exactly 1 boot option that matches... boot from that next. If there is 0, or more than 1 fail. 

Note: There will need to be a change to the sudoers file in vxsuite-complete-system to allow vx-ui to call efibootmgr with no password. 