### PR TITLE
fix(kiosk) add fallback boot menu bootable option and fix regex

### DIFF
--- a/src/ipc/prepare-boot-usb.test.ts
+++ b/src/ipc/prepare-boot-usb.test.ts
@@ -98,8 +98,8 @@ test('prepare-boot-usb returns true when expected and sets correct boot order', 
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
-Boot0000* ubuntu	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/File(somefile.efi)
-Boot0001* Linpus Lite	HD(1,MDR,0x314d08f,0x800,0x100000)/File(\\EFI\\boot\\grubx64.efi)RC
+Boot0000* ubuntu 	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/File(somefile.efi)
+Boot0001* Linpus Lite   	HD(1,MDR,0x314d08f,0x800,0x100000)/File(\\EFI\\boot\\grubx64.efi)RC
 Boot2001* EFI USB Device	RC
 Boot2002* EFI DVD/CDROM	RC
 Boot2003* EFI Network	RC
@@ -148,7 +148,7 @@ Boot0000* ubuntu	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/F
 Boot2001* EFI USB Device	RC
 Boot2002* EFI DVD/CDROM	RC
 Boot2003* EFI Network	RC
-Boot200E Boot Menu	RC
+Boot200E  Boot Menu	RC
        `,
     stderr: '',
   })

--- a/src/ipc/prepare-boot-usb.ts
+++ b/src/ipc/prepare-boot-usb.ts
@@ -1,14 +1,14 @@
 import makeDebug from 'debug'
-import { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { IpcMain } from 'electron'
 import exec from '../utils/exec'
-import { join } from 'path'
 
 export const channel = 'prepare-boot-usb'
 const debug = makeDebug('kiosk-browser:prepare-boot-usb')
 
-const BootableOptionPattern = /^Boot([0-9]+)\*\s(.+)\s(.+)$/
+const BootableOptionPattern = /^Boot([0-9a-fA-F]+)\*?\s(.+)\s(.+)$/
 const HardDriveDetailsPattern = /^HD\(.+,.+,(.+),.+,.+\).+$/
 const CurrentBootPattern = /^BootCurrent:\s*(.+)$/
+const BOOT_MENU_OPTION = 'Boot Menu'
 
 export interface BootOption {
   bootNumber: string // The string representing the boot number i.e. `0001`
@@ -96,6 +96,11 @@ async function prepareToBootFromUsb(): Promise<boolean> {
         bootableUsbOption = matchingBootOption
       }
     }
+  }
+  if (bootableUsbOption === undefined) {
+    bootableUsbOption = bootOptions.find(
+      bootOption => bootOption.bootLabel === BOOT_MENU_OPTION,
+    )
   }
   if (bootableUsbOption === undefined) {
     debug('No bootable usb device was found.')

--- a/src/ipc/prepare-boot-usb.ts
+++ b/src/ipc/prepare-boot-usb.ts
@@ -5,7 +5,7 @@ import exec from '../utils/exec'
 export const channel = 'prepare-boot-usb'
 const debug = makeDebug('kiosk-browser:prepare-boot-usb')
 
-const BootableOptionPattern = /^Boot([0-9a-fA-F]+)\*?\s(.+)\s(.+)$/
+const BootableOptionPattern = /^Boot([0-9a-fA-F]+)\*?\s+(.+)\s+(.+)$/
 const HardDriveDetailsPattern = /^HD\(.+,.+,(.+),.+,.+\).+$/
 const CurrentBootPattern = /^BootCurrent:\s*(.+)$/
 const BOOT_MENU_OPTION = 'Boot Menu'


### PR DESCRIPTION
Adds a fallback boot option to return true and boot from the "Boot Menu" if that is a labelled entry in efibootmgr. Also fixes the regex as the boot number is hexadecimal and can contain letters A-F. 