### PR TITLE
chore(ts): configure VS Code to use installed TS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
The latest version of TS that ships wiith VS Code is not fully compatible with the code written in kiosk-browser. This fixes it to use the one installed by `yarn`. We should also update TypeScript.