### PR TITLE
fix: bring back `kiosk` global

### DIFF
--- a/src/ipc/clock.ts
+++ b/src/ipc/clock.ts
@@ -1,6 +1,5 @@
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { DateTime } from 'luxon';
-import { KioskBrowser } from '../../types/kiosk-window';
 import exec from '../utils/exec';
 
 export const channel = 'setClock';

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,12 +1,10 @@
 import makeDebug from 'debug';
-import { ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 import { MakeDirectoryOptions } from 'fs';
-import { KioskBrowser } from '../types/kiosk-window';
 import { channel as setClock } from './ipc/clock';
 import {
   channel as fileSystemGetEntriesChannel,
   FileSystemEntry,
-  FileSystemEntryType,
 } from './ipc/file-system-get-entries';
 import { channel as fileSystemMakeDirectory } from './ipc/file-system-make-directory';
 import { channel as fileSystemReadFileChannel } from './ipc/file-system-read-file';
@@ -14,10 +12,7 @@ import {
   BatteryInfo,
   channel as getBatteryInfoChannel,
 } from './ipc/get-battery-info';
-import {
-  channel as getPrinterInfoChannel,
-  PrinterInfo,
-} from './ipc/get-printer-info';
+import { channel as getPrinterInfoChannel } from './ipc/get-printer-info';
 import { channel as getUsbDrivesChannel, UsbDrive } from './ipc/get-usb-drives';
 import {
   channel as mountUsbDriveChannel,
@@ -49,210 +44,208 @@ function toDate(dateOrString: Date | string): Date {
     : dateOrString;
 }
 
-class Kiosk implements KioskBrowser.Kiosk {
-  public async print(options?: KioskBrowser.PrintOptions): Promise<void>;
-  public async print(
-    deviceName?: string,
-    paperSource?: string,
-    copies?: number,
-  ): Promise<void>;
-  public async print(
-    deviceNameOrOptions?: KioskBrowser.PrintOptions | string,
-    paperSource?: string,
-    copies?: number,
-  ): Promise<void> {
-    const options =
-      typeof deviceNameOrOptions === 'string'
-        ? {
-            deviceName: deviceNameOrOptions,
-            paperSource,
-            copies,
-          }
-        : deviceNameOrOptions ?? {};
-    debug('forwarding `print(%o)` to main process', options);
+function makeKiosk(): KioskBrowser.Kiosk {
+  return {
+    async print(
+      deviceNameOrOptions?: KioskBrowser.PrintOptions | string,
+      paperSource?: string,
+      copies?: number,
+    ): Promise<void> {
+      const options =
+        typeof deviceNameOrOptions === 'string'
+          ? {
+              deviceName: deviceNameOrOptions,
+              paperSource,
+              copies,
+            }
+          : deviceNameOrOptions ?? {};
+      debug('forwarding `print(%o)` to main process', options);
 
-    if (typeof options !== 'undefined' && typeof options !== 'object') {
-      throw new TypeError(
-        `expected an options object for print, got ${typeof options}`,
-      );
-    }
+      if (typeof options !== 'undefined' && typeof options !== 'object') {
+        throw new TypeError(
+          `expected an options object for print, got ${typeof options}`,
+        );
+      }
 
-    await ipcRenderer.invoke(printChannel, options);
-  }
-
-  public async printToPDF(): Promise<Uint8Array> {
-    debug('forwarding `printToPDF()` to main process');
-    return (await ipcRenderer.invoke(printToPDFChannel)) as Uint8Array;
-  }
-
-  public async getBatteryInfo(): Promise<BatteryInfo | undefined> {
-    debug('forwarding `getBatteryInfo` to main process');
-    return (await ipcRenderer.invoke(getBatteryInfoChannel)) as
-      | BatteryInfo
-      | undefined;
-  }
-
-  public async getPrinterInfo(): Promise<PrinterInfo[]> {
-    debug('forwarding `getPrinterInfo` to main process');
-    return (await ipcRenderer.invoke(getPrinterInfoChannel)) as PrinterInfo[];
-  }
-
-  public async getUsbDrives(): Promise<UsbDrive[]> {
-    debug('forwarding `getUsbDrives` to main process');
-    return (await ipcRenderer.invoke(getUsbDrivesChannel)) as UsbDrive[];
-  }
-
-  public async mountUsbDrive(
-    optionsOrDevice: string | MountUsbDriveOptions,
-  ): Promise<void> {
-    debug('forwarding `mountUsbDrive` to main process');
-    await ipcRenderer.invoke(
-      mountUsbDriveChannel,
-      typeof optionsOrDevice === 'string'
-        ? { device: optionsOrDevice }
-        : optionsOrDevice,
-    );
-  }
-
-  public async unmountUsbDrive(device: string): Promise<void> {
-    debug('forwarding `unmountUsbDrive` to main process');
-    await ipcRenderer.invoke(unmountUsbDriveChannel, device);
-  }
-
-  public FileSystemEntryType = FileSystemEntryType;
-
-  public async getFileSystemEntries(path: string): Promise<FileSystemEntry[]> {
-    debug('forwarding `getFileSystemEntries` to main process');
-    const result = (await ipcRenderer.invoke(
-      fileSystemGetEntriesChannel,
-      path,
-    )) as FileSystemEntry[];
-    return result.map((entry) => ({
-      ...entry,
-      mtime: toDate(entry.mtime),
-      atime: toDate(entry.atime),
-      ctime: toDate(entry.ctime),
-    }));
-  }
-
-  public async readFile(path: string): Promise<Buffer>;
-  public async readFile(path: string, encoding: string): Promise<string>;
-  public async readFile(...args: unknown[]): Promise<Buffer | string> {
-    debug('forwarding `readFile` to main process');
-    return (await ipcRenderer.invoke(fileSystemReadFileChannel, ...args)) as
-      | Buffer
-      | string;
-  }
-
-  public async writeFile(path: string): Promise<FileWriter>;
-  public async writeFile(path: string, content: Buffer | string): Promise<void>;
-  public async writeFile(
-    path: string,
-    content?: Buffer | string,
-  ): Promise<FileWriter | void> {
-    debug('forwarding `writeFile` to main process');
-    const writer = await fromPath(path);
-
-    if (typeof content !== 'undefined') {
-      await writer.write(content);
-      await writer.end();
-    } else {
-      return writer;
-    }
-  }
-
-  public async makeDirectory(
-    path: string,
-    options: MakeDirectoryOptions = {},
-  ): Promise<void> {
-    debug('forwarding `makeDirectory` to main process');
-    await ipcRenderer.invoke(fileSystemMakeDirectory, path, options);
-  }
-
-  public storage = {
-    async set(key: string, value: object): Promise<void> {
-      debug('forwarding `storageSet` to main process');
-      await ipcRenderer.invoke(storageSetChannel, key, value);
+      await ipcRenderer.invoke(printChannel, options);
     },
 
-    async get<T extends object>(key: string): Promise<T | undefined> {
-      debug('forwarding `storageGet` to main process');
-      return (await ipcRenderer.invoke(storageGetChannel, key)) as
-        | T
+    async printToPDF(): Promise<Uint8Array> {
+      debug('forwarding `printToPDF()` to main process');
+      return (await ipcRenderer.invoke(printToPDFChannel)) as Uint8Array;
+    },
+
+    async getBatteryInfo(): Promise<BatteryInfo | undefined> {
+      debug('forwarding `getBatteryInfo` to main process');
+      return (await ipcRenderer.invoke(getBatteryInfoChannel)) as
+        | BatteryInfo
         | undefined;
     },
 
-    async remove(key: string): Promise<void> {
-      debug('forwarding `storageRemove` to main process');
-      await ipcRenderer.invoke(storageRemoveChannel, key);
+    async getPrinterInfo(): Promise<KioskBrowser.PrinterInfo[]> {
+      debug('forwarding `getPrinterInfo` to main process');
+      return (await ipcRenderer.invoke(
+        getPrinterInfoChannel,
+      )) as KioskBrowser.PrinterInfo[];
     },
 
-    async clear(): Promise<void> {
-      debug('forwarding `storageClear` to main process');
-      await ipcRenderer.invoke(storageClearChannel);
+    async getUsbDrives(): Promise<UsbDrive[]> {
+      debug('forwarding `getUsbDrives` to main process');
+      return (await ipcRenderer.invoke(getUsbDrivesChannel)) as UsbDrive[];
+    },
+
+    async mountUsbDrive(
+      optionsOrDevice: string | MountUsbDriveOptions,
+    ): Promise<void> {
+      debug('forwarding `mountUsbDrive` to main process');
+      await ipcRenderer.invoke(
+        mountUsbDriveChannel,
+        typeof optionsOrDevice === 'string'
+          ? { device: optionsOrDevice }
+          : optionsOrDevice,
+      );
+    },
+
+    async unmountUsbDrive(device: string): Promise<void> {
+      debug('forwarding `unmountUsbDrive` to main process');
+      await ipcRenderer.invoke(unmountUsbDriveChannel, device);
+    },
+
+    async getFileSystemEntries(path: string): Promise<FileSystemEntry[]> {
+      debug('forwarding `getFileSystemEntries` to main process');
+      const result = (await ipcRenderer.invoke(
+        fileSystemGetEntriesChannel,
+        path,
+      )) as FileSystemEntry[];
+      return result.map((entry) => ({
+        ...entry,
+        mtime: toDate(entry.mtime),
+        atime: toDate(entry.atime),
+        ctime: toDate(entry.ctime),
+      }));
+    },
+
+    readFile: (async (...args: unknown[]): Promise<Uint8Array | string> => {
+      debug('forwarding `readFile` to main process');
+      return (await ipcRenderer.invoke(fileSystemReadFileChannel, ...args)) as
+        | Uint8Array
+        | string;
+    }) as KioskBrowser.Kiosk['readFile'],
+
+    writeFile: (async (
+      path: string,
+      content?: Uint8Array | string,
+    ): Promise<FileWriter | void> => {
+      debug('forwarding `writeFile` to main process');
+      const writer = await fromPath(path);
+
+      if (typeof content !== 'undefined') {
+        await writer.write(content);
+        await writer.end();
+      } else {
+        return writer;
+      }
+    }) as KioskBrowser.Kiosk['writeFile'],
+
+    async makeDirectory(
+      path: string,
+      options: MakeDirectoryOptions = {},
+    ): Promise<void> {
+      debug('forwarding `makeDirectory` to main process');
+      await ipcRenderer.invoke(fileSystemMakeDirectory, path, options);
+    },
+
+    storage: {
+      async set(key: string, value: object): Promise<void> {
+        debug('forwarding `storageSet` to main process');
+        await ipcRenderer.invoke(storageSetChannel, key, value);
+      },
+
+      async get<T extends object>(key: string): Promise<T | undefined> {
+        debug('forwarding `storageGet` to main process');
+        return (await ipcRenderer.invoke(storageGetChannel, key)) as
+          | T
+          | undefined;
+      },
+
+      async remove(key: string): Promise<void> {
+        debug('forwarding `storageRemove` to main process');
+        await ipcRenderer.invoke(storageRemoveChannel, key);
+      },
+
+      async clear(): Promise<void> {
+        debug('forwarding `storageClear` to main process');
+        await ipcRenderer.invoke(storageClearChannel);
+      },
+    },
+
+    async setClock(params: KioskBrowser.SetClockParams): Promise<void> {
+      debug('forwarding `setClock` to main process');
+      await ipcRenderer.invoke(setClock, params);
+    },
+
+    totp: {
+      async get(): Promise<TotpInfo | undefined> {
+        debug('forwarding `totp.get` to main process');
+        return (await ipcRenderer.invoke(totpGetChannel)) as
+          | TotpInfo
+          | undefined;
+      },
+    },
+
+    async sign(params: SignParams): Promise<string> {
+      debug('forwarding `sign` to main process');
+      return (await ipcRenderer.invoke(signChannel, params)) as string;
+    },
+
+    async prepareToBootFromUsb(): Promise<boolean> {
+      debug('forwarding `prepareToBootFromUsb` to main process');
+      return (await ipcRenderer.invoke(prepareBootUsbChannel)) as boolean;
+    },
+
+    async log(message: string): Promise<void> {
+      debug('forwarding `log` to the main process');
+      await ipcRenderer.invoke(logChannel, message);
+    },
+
+    /**
+     * Gets an observable that yields the current set of connected USB devices as
+     * devices are added and removed.
+     *
+     * Given a set of initial devices (e.g. {mouse, keyboard}), a subscriber would
+     * receive the initial set. Once a new device is added (e.g. flash drive), that
+     * first subscriber receives a new set (e.g. {mouse, keyboard, flash drive}).
+     * New subscribers immediately receive the same current set.
+     */
+    devices: buildDevicesObservable(ipcRenderer),
+
+    /**
+     * Gets an observable that yields the current printer info whenever a printer
+     * is added or removed.
+     */
+    printers: buildPrinterInfoObservable(ipcRenderer),
+
+    async saveAs(
+      options?: PromptToSaveOptions,
+    ): Promise<FileWriter | undefined> {
+      return await fromPrompt(options);
+    },
+
+    quit(exitCode?: number): void {
+      debug('forwarding `quit` to main process');
+      if (typeof exitCode === 'undefined') {
+        void ipcRenderer.invoke(quitChannel);
+      } else {
+        void ipcRenderer.invoke(quitChannel, exitCode);
+      }
+    },
+
+    async reboot(): Promise<void> {
+      debug('forwarding `reboot` to the main process');
+      await ipcRenderer.invoke(rebootChannel);
     },
   };
-
-  public async setClock(params: KioskBrowser.SetClockParams): Promise<void> {
-    debug('forwarding `setClock` to main process');
-    await ipcRenderer.invoke(setClock, params);
-  }
-
-  public totp = {
-    async get(): Promise<TotpInfo | undefined> {
-      debug('forwarding `totp.get` to main process');
-      return (await ipcRenderer.invoke(totpGetChannel)) as TotpInfo | undefined;
-    },
-  };
-
-  public async sign(params: SignParams): Promise<string> {
-    debug('forwarding `sign` to main process');
-    return (await ipcRenderer.invoke(signChannel, params)) as string;
-  }
-
-  public async prepareToBootFromUsb(): Promise<boolean> {
-    debug('forwarding `prepareToBootFromUsb` to main process');
-    return (await ipcRenderer.invoke(prepareBootUsbChannel)) as boolean;
-  }
-
-  public async log(message: string): Promise<void> {
-    debug('forwarding `log` to the main process');
-    await ipcRenderer.invoke(logChannel, message);
-  }
-
-  /**
-   * Gets an observable that yields the current set of connected USB devices as
-   * devices are added and removed.
-   *
-   * Given a set of initial devices (e.g. {mouse, keyboard}), a subscriber would
-   * receive the initial set. Once a new device is added (e.g. flash drive), that
-   * first subscriber receives a new set (e.g. {mouse, keyboard, flash drive}).
-   * New subscribers immediately receive the same current set.
-   */
-  public devices = buildDevicesObservable(ipcRenderer);
-
-  /**
-   * Gets an observable that yields the current printer info whenever a printer
-   * is added or removed.
-   */
-  public printers = buildPrinterInfoObservable(ipcRenderer);
-
-  public async saveAs(
-    options?: PromptToSaveOptions,
-  ): Promise<FileWriter | undefined> {
-    return await fromPrompt(options);
-  }
-
-  public quit(): void {
-    debug('forwarding `quit` to main process');
-    void ipcRenderer.invoke(quitChannel);
-  }
-
-  public async reboot(): Promise<void> {
-    debug('forwarding `reboot` to the main process');
-    await ipcRenderer.invoke(rebootChannel);
-  }
 }
 
 debug('setting up window.kiosk');
-window.kiosk = new Kiosk();
+contextBridge.exposeInMainWorld('kiosk', makeKiosk());

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -1,23 +1,10 @@
-import { Observable } from 'rxjs'
-import { Device } from 'usb-detection'
-import { BatteryInfo } from '../src/ipc/get-battery-info'
-import { PrinterInfo } from '../src/ipc/get-printer-info'
-import { PromptToSaveOptions } from '../src/ipc/saveAs'
-import { FileWriter } from '../src/utils/FileWriter'
-
 declare namespace KioskBrowser {
-  interface PrintOptions {
-    deviceName?: string
-    paperSource?: string
-    copies?: number
+  export interface BatteryInfo {
+    discharging: boolean;
+    level: number; // Number between 0–1
   }
 
-  interface SetClockParams {
-    isoDatetime: string
-    IANAZone: string
-  }
-
-  type PrintSides =
+  export type PrintSides =
     /**
      * One page per sheet, aka simplex or "Duplex=None".
      */
@@ -35,27 +22,219 @@ declare namespace KioskBrowser {
      * that a right-side up portrait sheet flipped over on the short edge remains
      * right-side up, i.e. a bound-at-the-top ring binder.
      */
-    | 'two-sided-short-edge'
+    | 'two-sided-short-edge';
 
-  interface Kiosk {
-    getBatteryInfo(): Promise<BatteryInfo | undefined>
-    getPrinterInfo(): Promise<PrinterInfo[]>
-    devices: Observable<Iterable<Device>>
-    print(options?: KioskBrowser.PrintOptions): Promise<void>
-    print(
-      deviceName?: string,
-      paperSource?: string,
-      copies?: number,
-      sides?: PrintSides,
-    ): Promise<void>
-    saveAs(options?: PromptToSaveOptions): Promise<FileWriter | undefined>
-    setClock(params: SetClockParams): Promise<void>
-    quit(): void
+  export interface PrintOptions {
+    deviceName?: string;
+    paperSource?: string;
+    copies?: number;
+    sides?: PrintSides;
+  }
+
+  /**
+   * IPP printer-state-reasons explain what's going on with a printer in detail.
+   * Spec: https://datatracker.ietf.org/doc/html/rfc2911#section-4.4.12
+   * For a partial list of common printer-state-reasons, see
+   * getPrinterIppAttributes.ts in kiosk-browser. Since we don't know all
+   * possible reasons, we just type as string.
+   */
+  export type IppPrinterStateReason = string;
+
+  /**
+   * "Marker" is a general name for ink/toner/etc. CUPS implements a variety of
+   * marker-related IPP attributes prefixed with "marker-", e.g. "marker-levels".
+   * Spec: https://www.cups.org/doc/spec-ipp.html
+   */
+  export interface IppMarkerInfo {
+    name: string; // e.g. "black cartridge"
+    color: string; // e.g. "#000000"
+    type: string; // e.g. "toner-cartridge"
+    lowLevel: number; // e.g. 2
+    highLevel: number; // e.g. 100
+    level: number; // e.g. 83
+  }
+
+  /**
+   * A collection of status info about a printer we get via IPP.
+   */
+  export type PrinterIppAttributes =
+    | { state: 'unknown' } // We didn't get a response from the printer
+    | {
+        state: 'idle' | 'processing' | 'stopped';
+        stateReasons: IppPrinterStateReason[];
+        markerInfos: IppMarkerInfo[];
+      };
+
+  interface PrinterInfoBase {
+    // Docs: http://electronjs.org/docs/api/structures/printer-info
+    description: string;
+    isDefault: boolean;
+    name: string;
+    options?: { [key: string]: string };
+    // Added via kiosk-browser
+    connected: boolean;
+  }
+  /**
+   * The printer's basic info we get from Electron (e.g. name, description,
+   * options), plus its connection status and IPP attributes.
+   */
+  export type PrinterInfo = Omit<Electron.PrinterInfo, 'status'> &
+    PrinterIppAttributes & {
+      connected: boolean;
+    };
+
+  export interface Device {
+    locationId: number;
+    vendorId: number;
+    productId: number;
+    deviceName: string;
+    manufacturer: string;
+    serialNumber: string;
+    deviceAddress: number;
+  }
+
+  export interface UsbDrive {
+    deviceName: string;
+    mountPoint?: string;
+  }
+
+  export interface SaveAsOptions {
+    title?: string;
+    defaultPath?: string;
+    buttonLabel?: string;
+    filters?: FileFilter[];
+  }
+
+  export interface MakeDirectoryOptions {
+    recursive?: boolean;
+    mode?: number;
+  }
+
+  export interface FileFilter {
+    // Docs: http://electronjs.org/docs/api/structures/file-filter
+    extensions: string[];
+    name: string;
+  }
+
+  export enum FileSystemEntryType {
+    File = 1, // UV_DIRENT_FILE
+    Directory = 2, // UV_DIRENT_DIR
+    SymbolicLink = 3, // UV_DIRENT_LINK
+    FIFO = 4, // UV_DIRENT_FIFO
+    Socket = 5, // UV_DIRENT_SOCKET
+    CharacterDevice = 6, // UV_DIRENT_CHAR
+    BlockDevice = 7, // UV_DIRENT_BLOCK
+  }
+
+  export interface FileSystemEntry {
+    readonly name: string;
+    readonly path: string;
+    readonly type: FileSystemEntryType;
+    readonly size: number;
+    readonly mtime: Date;
+    readonly atime: Date;
+    readonly ctime: Date;
+  }
+
+  export interface FileWriter {
+    /**
+     * Writes a chunk to the file. May be called multiple times. Data will be
+     * written in the order of calls to `write`.
+     */
+    write(data: Uint8Array | string): Promise<void>;
+
+    /**
+     * Finishes writing to the file and closes it. Subsequent calls to `write`
+     * will fail. Resolves when the file is successfully closed.
+     */
+    end(): Promise<void>;
+
+    filename: string;
+  }
+
+  export interface SetClockParams {
+    isoDatetime: string;
+    IANAZone: string;
+  }
+
+  export interface TotpInfo {
+    isoDatetime: string;
+    code: string;
+  }
+
+  export interface SignParams {
+    signatureType: string;
+    payload: string;
+  }
+
+  export interface Kiosk {
+    print(options?: PrintOptions): Promise<void>;
+    getPrinterInfo(): Promise<PrinterInfo[]>;
+
+    /**
+     * Prints the current page to PDF and resolves with the PDF file bytes.
+     */
+    printToPDF(): Promise<Uint8Array>;
+    log(message: string): Promise<void>;
+
+    getBatteryInfo(): Promise<BatteryInfo | undefined>;
+    devices: import('rxjs').Observable<Iterable<Device>>;
+    printers: import('rxjs').Observable<Iterable<PrinterInfo>>;
+    quit(): void;
+
+    /**
+     * Opens a Save Dialog to allow the user to choose a destination for a file.
+     * Once chosen, resolves with a handle to the file to write data to it.
+     */
+    saveAs(options?: SaveAsOptions): Promise<FileWriter | undefined>;
+
+    /**
+     * Writes a file to a specified file path
+     */
+    writeFile(path: string): Promise<FileWriter>;
+    writeFile(path: string, content: Uint8Array | string): Promise<void>;
+
+    /*
+     * Creates a directory at the specified path.
+     */
+    makeDirectory(path: string, options?: MakeDirectoryOptions): Promise<void>;
+
+    // USB sticks
+    getUsbDrives(): Promise<UsbDrive[]>;
+    mountUsbDrive(device: string): Promise<void>;
+    unmountUsbDrive(device: string): Promise<void>;
+
+    /**
+     * Reads the list of files at a specified directory path
+     */
+    getFileSystemEntries(path: string): Promise<FileSystemEntry[]>;
+
+    /**
+     * Reads a file from a specified path
+     */
+    readFile(path: string): Promise<Uint8Array>;
+    readFile(path: string, encoding: string): Promise<string>;
+
+    // storage
+    storage: {
+      set(key: string, value: unknown): Promise<void>;
+      get(key: string): Promise<unknown | undefined>;
+      remove(key: string): Promise<void>;
+      clear(): Promise<void>;
+    };
+
+    setClock(params: SetClockParams): Promise<void>;
+
+    totp: {
+      get(): Promise<TotpInfo | undefined>;
+    };
+
+    sign(params: SignParams): Promise<string>;
+
+    reboot(): Promise<void>;
+
+    prepareToBootFromUsb(): Promise<boolean>;
   }
 }
 
-declare global {
-  interface Window {
-    kiosk?: KioskBrowser.Kiosk
-  }
-}
+declare let kiosk: KioskBrowser.Kiosk | undefined;


### PR DESCRIPTION
Depends on #116

In Electron v12 they made `contextIsolation: true` the default, which means we can no longer access certain things from renderer processes. Thus, we can't just assign `kiosk` to `window`. We have to use [`contextBridge.exposeInMainWorld`](https://www.electronjs.org/docs/latest/api/context-bridge#contextbridgeexposeinmainworldapikey-api). Because of how this API works we cannot expose a class with prototype methods and have them be callable, so instead we now build `Kiosk` objects using a factory pattern instead. This makes more sense anyway since they're not really a class with internal state.

Also updates the `KioskBrowser` types from `vxsuite`, which by necessity has had the more up-to-date version.

Fixes #114 