### PR TITLE
fix: make `kiosk.devices` and `kiosk.printers` work again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain, IpcMain } from 'electron';
 import storage from 'electron-json-storage';
 import { join } from 'path';
 import { Observable, of } from 'rxjs';
-import usbDetection, { Device } from 'usb-detection';
+import usbDetection from 'usb-detection';
 import registerSetClock from './ipc/clock';
 import registerManageDeviceSubscriptionHandler from './ipc/device-subscription';
 import registerFileSystemGetEntriesHandler from './ipc/file-system-get-entries';
@@ -41,7 +41,7 @@ export type RegisterIpcHandler = (
     autoconfiguredPrinter,
   }: {
     options: Options;
-    changedDevices: Observable<Iterable<Device>>;
+    changedDevices: Observable<Iterable<KioskBrowser.Device>>;
     autoconfiguredPrinter: Observable<void>;
   },
 ) => (() => void) | void;

--- a/src/ipc/device-subscription.ts
+++ b/src/ipc/device-subscription.ts
@@ -1,6 +1,9 @@
+import makeDebug from 'debug';
 import { IpcMainInvokeEvent, WebContents } from 'electron';
 import { Subscription } from 'rxjs';
 import { RegisterIpcHandler } from '..';
+
+const debug = makeDebug('kiosk-browser:device-subscription');
 
 export const channel = 'device-subscription';
 
@@ -8,11 +11,16 @@ export const channel = 'device-subscription';
  * Subscribe to add/remove USB device events.
  */
 export const register: RegisterIpcHandler = (ipcMain, { changedDevices }) => {
+  debug('registering handler with channel: %s', channel);
   const subscriptions = new Map<WebContents, Subscription>();
 
   ipcMain.handle(
     channel,
     (event: IpcMainInvokeEvent, { subscribe }: { subscribe: boolean }) => {
+      debug(
+        'received request to subscribe/unsubscribe: subscribe=%s',
+        subscribe,
+      );
       const webContents = event.sender;
       const subscription = subscriptions.get(webContents);
 
@@ -20,6 +28,7 @@ export const register: RegisterIpcHandler = (ipcMain, { changedDevices }) => {
       subscription?.unsubscribe();
 
       if (subscribe) {
+        debug('subscribing to device changes');
         const subscription = changedDevices.subscribe((set) =>
           webContents.send(channel, Array.from(set)),
         );

--- a/src/ipc/get-printer-info.test.ts
+++ b/src/ipc/get-printer-info.test.ts
@@ -152,14 +152,14 @@ describe('getPrinterInfo', () => {
 
 test('registers an IPC handler for getting printer info', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters(): Electron.PrinterInfo[] {
-      return [
+    getPrintersAsync(): Promise<Electron.PrinterInfo[]> {
+      return Promise.resolve([
         fakeElectronPrinter({
           options: {
             'device-uri': 'usb://HP/Color%20LaserJet?serial=1234',
           },
         }),
-      ];
+      ]);
     },
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);

--- a/src/ipc/get-printer-info.ts
+++ b/src/ipc/get-printer-info.ts
@@ -1,12 +1,12 @@
-import { IpcMainInvokeEvent, IpcMain } from 'electron';
-import getConnectedDeviceURIs from '../utils/printing/getConnectedDeviceURIs';
-import printerSchemes from '../utils/printing/printerSchemes';
+import { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { debug } from '../utils/printing';
+import getConnectedDeviceURIs from '../utils/printing/getConnectedDeviceURIs';
 import {
   getPrinterIppAttributes,
-  PrinterIppAttributes,
   IppPrinterState,
+  PrinterIppAttributes,
 } from '../utils/printing/getPrinterIppAttributes';
+import printerSchemes from '../utils/printing/printerSchemes';
 import { retry, retryUntil } from '../utils/retry';
 
 export const channel = 'get-printer-info';
@@ -85,7 +85,7 @@ export async function getPrinterInfo(
  * Registers a handler to get printer info.
  */
 export default function register(ipcMain: IpcMain): void {
-  ipcMain.handle(channel, (event: IpcMainInvokeEvent) =>
-    getPrinterInfo(event.sender.getPrinters()),
+  ipcMain.handle(channel, async (event: IpcMainInvokeEvent) =>
+    getPrinterInfo(await event.sender.getPrintersAsync()),
   );
 }

--- a/src/ipc/print.test.ts
+++ b/src/ipc/print.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 
 test('registers a handler to trigger a print', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockResolvedValueOnce(Buffer.of(50, 44, 46)), // PDF
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);
@@ -46,7 +46,7 @@ test('registers a handler to trigger a print', async () => {
 
 test('uses the preferred printer if none is provided', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockResolvedValueOnce(Buffer.of(50, 44, 46)), // PDF
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);
@@ -72,7 +72,7 @@ test('uses the preferred printer if none is provided', async () => {
 
 test('propagates errors', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockRejectedValueOnce(new Error('PCLOADLETTER')),
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);
@@ -87,7 +87,7 @@ test('propagates errors', async () => {
 
 test('prints a specified number of copies', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockResolvedValueOnce(Buffer.of(50, 44, 46)), // PDF
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);
@@ -113,7 +113,7 @@ test('prints a specified number of copies', async () => {
 
 test('does not allow fractional copies', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockResolvedValueOnce(Buffer.of(50, 44, 46)), // PDF
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);
@@ -136,7 +136,7 @@ test('does not allow fractional copies', async () => {
 
 test('allows specifying one-sided duplex', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockResolvedValueOnce(Buffer.of(50, 44, 46)), // PDF
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);
@@ -160,7 +160,7 @@ test('allows specifying one-sided duplex', async () => {
 
 test('allows specifying two-sided-short-edge duplex', async () => {
   const sender: Partial<WebContents> = {
-    getPrinters: () => [],
+    getPrintersAsync: () => Promise.resolve([]),
     printToPDF: jest.fn().mockResolvedValueOnce(Buffer.of(50, 44, 46)), // PDF
   };
   const { ipcMain, ipcRenderer } = fakeIpc(sender);

--- a/src/ipc/print.ts
+++ b/src/ipc/print.ts
@@ -109,7 +109,8 @@ export default function register(ipcMain: IpcMain): void {
       await printData({
         data,
         deviceName:
-          deviceName ?? getPreferredPrinterName(event.sender.getPrinters()),
+          deviceName ??
+          getPreferredPrinterName(await event.sender.getPrintersAsync()),
         paperSource,
         copies,
         sides,

--- a/src/ipc/sign.test.ts
+++ b/src/ipc/sign.test.ts
@@ -1,5 +1,4 @@
 import { Subject } from 'rxjs';
-import { Device } from 'usb-detection';
 import { fakeIpc } from '../../test/ipc';
 import mockOf from '../../test/mockOf';
 import exec from '../utils/exec';
@@ -13,7 +12,7 @@ beforeEach(() => {
   execMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
-const changedDevices = new Subject<Iterable<Device>>();
+const changedDevices = new Subject<Iterable<KioskBrowser.Device>>();
 const autoconfiguredPrinter = new Subject<void>();
 
 test('call to sign invokes the right signify command, but only if signatureType is well-formed', async () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,12 +1,12 @@
 import makeDebug from 'debug';
 import { contextBridge, ipcRenderer } from 'electron';
 import { MakeDirectoryOptions } from 'fs';
-import { channel as setClock } from './ipc/clock';
+import { channel as setClockChannel } from './ipc/clock';
 import {
   channel as fileSystemGetEntriesChannel,
   FileSystemEntry,
 } from './ipc/file-system-get-entries';
-import { channel as fileSystemMakeDirectory } from './ipc/file-system-make-directory';
+import { channel as fileSystemMakeDirectoryChannel } from './ipc/file-system-make-directory';
 import { channel as fileSystemReadFileChannel } from './ipc/file-system-read-file';
 import {
   BatteryInfo,
@@ -14,24 +14,24 @@ import {
 } from './ipc/get-battery-info';
 import { channel as getPrinterInfoChannel } from './ipc/get-printer-info';
 import { channel as getUsbDrivesChannel, UsbDrive } from './ipc/get-usb-drives';
+import { channel as logChannel } from './ipc/log';
 import {
   channel as mountUsbDriveChannel,
   Options as MountUsbDriveOptions,
 } from './ipc/mount-usb-drive';
+import { channel as prepareBootUsbChannel } from './ipc/prepare-boot-usb';
 import { channel as printChannel } from './ipc/print';
 import { channel as printToPDFChannel } from './ipc/printToPDF';
 import { channel as quitChannel } from './ipc/quit';
+import { channel as rebootChannel } from './ipc/reboot';
 import { PromptToSaveOptions } from './ipc/saveAs';
+import { channel as signChannel, SignParams } from './ipc/sign';
 import { channel as storageClearChannel } from './ipc/storage-clear';
 import { channel as storageGetChannel } from './ipc/storage-get';
 import { channel as storageRemoveChannel } from './ipc/storage-remove';
 import { channel as storageSetChannel } from './ipc/storage-set';
-import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive';
 import { channel as totpGetChannel, TotpInfo } from './ipc/totp-get';
-import { channel as signChannel, SignParams } from './ipc/sign';
-import { channel as logChannel } from './ipc/log';
-import { channel as rebootChannel } from './ipc/reboot';
-import { channel as prepareBootUsbChannel } from './ipc/prepare-boot-usb';
+import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive';
 import buildDevicesObservable from './utils/buildDevicesObservable';
 import buildPrinterInfoObservable from './utils/buildPrinterInfoObservable';
 import { FileWriter, fromPath, fromPrompt } from './utils/FileWriter';
@@ -152,7 +152,7 @@ function makeKiosk(): KioskBrowser.Kiosk {
       options: MakeDirectoryOptions = {},
     ): Promise<void> {
       debug('forwarding `makeDirectory` to main process');
-      await ipcRenderer.invoke(fileSystemMakeDirectory, path, options);
+      await ipcRenderer.invoke(fileSystemMakeDirectoryChannel, path, options);
     },
 
     storage: {
@@ -181,7 +181,7 @@ function makeKiosk(): KioskBrowser.Kiosk {
 
     async setClock(params: KioskBrowser.SetClockParams): Promise<void> {
       debug('forwarding `setClock` to main process');
-      await ipcRenderer.invoke(setClock, params);
+      await ipcRenderer.invoke(setClockChannel, params);
     },
 
     totp: {

--- a/src/utils/buildDevicesObservable.ts
+++ b/src/utils/buildDevicesObservable.ts
@@ -1,7 +1,5 @@
 import { IpcRenderer } from 'electron';
-import { Observable } from 'rxjs';
-import { Device } from './usb';
-import { channel as manageDeviceSubscriptionChannel } from '../ipc/device-subscription';
+import { channel as deviceSubscriptionChannel } from '../ipc/device-subscription';
 import buildIpcMainForwardingObservable from './buildIpcMainForwardingObservable';
 
 /**
@@ -15,10 +13,10 @@ import buildIpcMainForwardingObservable from './buildIpcMainForwardingObservable
  */
 const buildDevicesObservable = (
   ipcRenderer: IpcRenderer,
-): Observable<Iterable<Device>> =>
-  buildIpcMainForwardingObservable<Iterable<Device>>(
+): KioskBrowser.Observable<Iterable<KioskBrowser.Device>> =>
+  buildIpcMainForwardingObservable<Iterable<KioskBrowser.Device>>(
     ipcRenderer,
-    manageDeviceSubscriptionChannel,
+    deviceSubscriptionChannel,
   );
 
 export default buildDevicesObservable;

--- a/src/utils/buildIpcMainForwardingObservable.test.ts
+++ b/src/utils/buildIpcMainForwardingObservable.test.ts
@@ -12,7 +12,7 @@ test('subscribes on first connection', () => {
   );
   expect(handler).not.toHaveBeenCalled();
 
-  observable.subscribe();
+  observable.subscribe(jest.fn());
   expect(handler).toHaveBeenCalledWith(expect.anything(), { subscribe: true });
 });
 
@@ -27,7 +27,9 @@ test('unsubscribes on last disconnection', () => {
   );
   expect(handler).not.toHaveBeenCalled();
 
-  observable.subscribe().unsubscribe();
+  const unsubscribe = observable.subscribe(jest.fn());
+  unsubscribe();
+
   expect(handler).toHaveBeenNthCalledWith(1, expect.anything(), {
     subscribe: true,
   });

--- a/src/utils/buildPrinterInfoObservable.ts
+++ b/src/utils/buildPrinterInfoObservable.ts
@@ -1,18 +1,17 @@
 import { IpcRenderer } from 'electron';
-import { Observable } from 'rxjs';
-import { channel as managePrinterSubscriptionChannel } from '../ipc/printer-subscription';
-import buildIpcMainForwardingObservable from './buildIpcMainForwardingObservable';
+import { channel as printerSubscriptionChannel } from '../ipc/printer-subscription';
 import { PrinterInfo } from '../ipc/get-printer-info';
+import buildIpcMainForwardingObservable from './buildIpcMainForwardingObservable';
 
 /**
  * Build a new observable that yields the current set of printers.
  */
-const buildDevicesObservable = (
+const buildPrinterInfoObservable = (
   ipcRenderer: IpcRenderer,
-): Observable<Iterable<PrinterInfo>> =>
+): KioskBrowser.Observable<Iterable<PrinterInfo>> =>
   buildIpcMainForwardingObservable<Iterable<PrinterInfo>>(
     ipcRenderer,
-    managePrinterSubscriptionChannel,
+    printerSubscriptionChannel,
   );
 
-export default buildDevicesObservable;
+export default buildPrinterInfoObservable;

--- a/src/utils/printing/autoconfigurePrinter.test.ts
+++ b/src/utils/printing/autoconfigurePrinter.test.ts
@@ -1,6 +1,5 @@
 import autoconfigurePrinter from './autoconfigurePrinter';
 import { Subject } from 'rxjs';
-import { Device } from '../usb';
 import fakeDevice from '../../../test/fakeDevice';
 import configurePrinterFromDevice from './configurePrinterFromDevice';
 import mockOf from '../../../test/mockOf';
@@ -14,7 +13,7 @@ test('configurable device added', async () => {
     configurePrinterDeferred.promise,
   );
 
-  const observable = new Subject<Iterable<Device>>();
+  const observable = new Subject<Iterable<KioskBrowser.Device>>();
   const config = {
     printerName: 'VxPrinter',
     printers: [],
@@ -49,7 +48,7 @@ test('unconfigurable device added', async () => {
     configurePrinterDeferred.promise,
   );
 
-  const observable = new Subject<Iterable<Device>>();
+  const observable = new Subject<Iterable<KioskBrowser.Device>>();
   const config = {
     printerName: 'VxPrinter',
     printers: [],

--- a/src/utils/printing/autoconfigurePrinter.ts
+++ b/src/utils/printing/autoconfigurePrinter.ts
@@ -1,14 +1,15 @@
-import { Device } from '../usb';
 import { Observable } from 'rxjs';
 import { debug, PrintConfig } from '.';
 import configurePrinterFromDevice from './configurePrinterFromDevice';
 
 export default function autoconfigurePrinter(
   config: PrintConfig,
-  devices: Observable<Iterable<Device>>,
+  devices: Observable<Iterable<KioskBrowser.Device>>,
 ): Observable<void> {
   return new Observable((subscriber) =>
-    devices.subscribe(function onDevicesUpdate(list: Iterable<Device>): void {
+    devices.subscribe(function onDevicesUpdate(
+      list: Iterable<KioskBrowser.Device>,
+    ): void {
       for (const device of list) {
         configurePrinterFromDevice(config, device)
           .then((configured) => {

--- a/src/utils/printing/configurePrinterFromDevice.ts
+++ b/src/utils/printing/configurePrinterFromDevice.ts
@@ -4,11 +4,10 @@ import configurePrinter from './configurePrinter';
 import getConnectedDeviceURIs from './getConnectedDeviceURIs';
 import getPrinterDeviceURI from './getPrinterDeviceURI';
 import { debug, PrintConfig } from '.';
-import { Device } from '../usb';
 
 export default async function configurePrinterFromDevice(
   config: PrintConfig,
-  device: Device,
+  device: KioskBrowser.Device,
 ): Promise<boolean> {
   const printer = getPrinterConfigForDevice(config, device);
 

--- a/src/utils/printing/getPrinterConfigForDevice.ts
+++ b/src/utils/printing/getPrinterConfigForDevice.ts
@@ -1,12 +1,11 @@
 import { Printer, PrintConfig } from '.';
-import { Device } from '../usb';
 
 /**
  * Finds a printer config matching a USB device.
  */
 export default function getPrinterConfigForDevice(
   config: PrintConfig,
-  device: Device,
+  device: KioskBrowser.Device,
 ): Printer | undefined {
   for (const printer of config.printers) {
     if (

--- a/src/utils/usb.test.ts
+++ b/src/utils/usb.test.ts
@@ -1,4 +1,4 @@
-import usbDetection, { Device } from 'usb-detection';
+import usbDetection from 'usb-detection';
 import fakeDevice from '../../test/fakeDevice';
 import mockOf from '../../test/mockOf';
 import deferred from './deferred';
@@ -42,9 +42,9 @@ test('yields initial devices', async () => {
   ]);
 
   const devices = new USBDetectionManager(usbDetection).devices;
-  const defer = deferred<ImmutableSet<Device>>();
+  const defer = deferred<ImmutableSet<KioskBrowser.Device>>();
   const subscriber = jest
-    .fn<void, [ImmutableSet<Device>]>()
+    .fn<void, [ImmutableSet<KioskBrowser.Device>]>()
     .mockImplementation(defer.resolve);
 
   devices.subscribe(subscriber);
@@ -72,7 +72,7 @@ test('does not include removed devices in initial yield', async () => {
     .mockRejectedValue(new Error('find was called too many times'));
 
   // Ensure device monitoring is on.
-  const defer = deferred<ImmutableSet<Device>>();
+  const defer = deferred<ImmutableSet<KioskBrowser.Device>>();
   devices.subscribe(defer.resolve);
   await defer.promise;
 
@@ -80,12 +80,14 @@ test('does not include removed devices in initial yield', async () => {
   const [, onDeviceRemoved] =
     mockOf(usbDetection.on).mock.calls.find((call) => call[0] === 'remove') ??
     [];
-  for (const device of initialDevices) {
-    onDeviceRemoved?.(device);
+  for (let i = 0; i < initialDevices.length; i++) {
+    onDeviceRemoved?.(initialDevices.slice(i));
   }
 
-  const defer2 = deferred<ImmutableSet<Device>>();
-  const subscriber = jest.fn<void, [ImmutableSet<Device>]>(defer2.resolve);
+  const defer2 = deferred<ImmutableSet<KioskBrowser.Device>>();
+  const subscriber = jest.fn<void, [ImmutableSet<KioskBrowser.Device>]>(
+    defer2.resolve,
+  );
 
   devices.subscribe(subscriber);
   await defer2.promise;

--- a/test/fakeDevice.ts
+++ b/test/fakeDevice.ts
@@ -1,6 +1,6 @@
-import { Device } from '../src/utils/usb'
-
-export default function fakeDevice(props: Partial<Device> = {}): Device {
+export default function fakeDevice(
+  props: Partial<KioskBrowser.Device> = {},
+): KioskBrowser.Device {
   return {
     deviceName: 'fake device',
     deviceAddress: 0,
@@ -10,5 +10,5 @@ export default function fakeDevice(props: Partial<Device> = {}): Device {
     serialNumber: '12345',
     vendorId: 0,
     ...props,
-  }
+  };
 }

--- a/test/integration/support/minitest.ts
+++ b/test/integration/support/minitest.ts
@@ -182,7 +182,7 @@ async function runTest(testModule: TestModule, test: Test): Promise<boolean> {
       success: true,
     });
   } catch (error) {
-    console.error(`❌ ${test.name} failed`);
+    console.error(`❌ ${test.name} failed`, error);
     await report({
       testModulePath: testModule.path,
       test: test.name,

--- a/test/integration/tests/kiosk.test.ts
+++ b/test/integration/tests/kiosk.test.ts
@@ -1,3 +1,5 @@
+import { waitFor } from '../support/minitest';
+
 // Declare `kiosk` as a definitely defined global variable
 declare let kiosk: KioskBrowser.Kiosk;
 
@@ -48,6 +50,41 @@ test('print to PDF', async () => {
       .map((c) => String.fromCharCode(c))
       .join(''),
   ).toEqual(prelude);
+});
+
+test('devices', async () => {
+  let devices: KioskBrowser.Device[] | undefined;
+
+  const unsubscribe = kiosk.devices.subscribe((newDevices) => {
+    devices = [...newDevices];
+  });
+
+  await waitFor(() => {
+    expect(devices).toBeInstanceOf(Array);
+  });
+
+  unsubscribe();
+});
+
+// TODO: remove `.skip` once we've figured out why this test causes a crash:
+//
+//   Assertion 'udev->n_ref > 0' failed at src/libudev/libudev.c:106, function udev_unref(). Aborting.
+//
+test.skip('printers', async () => {
+  let printers: KioskBrowser.PrinterInfo[] | undefined;
+
+  const unsubscribe = kiosk.printers.subscribe((newPrinters) => {
+    printers = [...newPrinters];
+  });
+
+  await waitFor(
+    () => {
+      expect(printers).toBeInstanceOf(Array);
+    },
+    { timeout: 10_000 },
+  );
+
+  unsubscribe();
 });
 
 // force tooling to consider this a module

--- a/test/integration/tests/kiosk.test.ts
+++ b/test/integration/tests/kiosk.test.ts
@@ -1,6 +1,10 @@
 // Declare `kiosk` as a definitely defined global variable
 declare let kiosk: KioskBrowser.Kiosk;
 
+// This isn't actually Jest, so we can't use `jest`.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare let jest: never;
+
 test('storage', async () => {
   await kiosk.storage.clear();
   await kiosk.storage.set('some-key', { some: 'value' });

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -167,6 +167,10 @@ declare namespace KioskBrowser {
     payload: string;
   }
 
+  export interface Observable<T> {
+    subscribe(callback: (value: T) => void): () => void;
+  }
+
   export interface Kiosk {
     print(options?: PrintOptions): Promise<void>;
     getPrinterInfo(): Promise<PrinterInfo[]>;
@@ -178,8 +182,8 @@ declare namespace KioskBrowser {
     log(message: string): Promise<void>;
 
     getBatteryInfo(): Promise<BatteryInfo | undefined>;
-    devices: import('rxjs').Observable<Iterable<Device>>;
-    printers: import('rxjs').Observable<Iterable<PrinterInfo>>;
+    devices: Observable<Iterable<Device>>;
+    printers: Observable<Iterable<PrinterInfo>>;
     quit(): void;
 
     /**

--- a/types/usb-detection.d.ts
+++ b/types/usb-detection.d.ts
@@ -5,33 +5,47 @@ declare module 'usb-detection' {
   //                 Rico Brase <https://github.com/RicoBrase>
 
   export interface Device {
-    locationId: number
-    vendorId: number
-    productId: number
-    deviceName: string
-    manufacturer: string
-    serialNumber: string
-    deviceAddress: number
+    locationId: number;
+    vendorId: number;
+    productId: number;
+    deviceName: string;
+    manufacturer: string;
+    serialNumber: string;
+    deviceAddress: number;
   }
 
   export function find(
     vid: number,
     pid: number,
     callback: (error: any, devices: Device[]) => any,
-  ): void
-  export function find(vid: number, pid: number): Promise<Device[]>
+  ): void;
+  export function find(vid: number, pid: number): Promise<Device[]>;
   export function find(
     vid: number,
     callback: (error: any, devices: Device[]) => any,
-  ): void
-  export function find(vid: number): Promise<Device[]>
-  export function find(callback: (error: any, devices: Device[]) => any): void
-  export function find(): Promise<Device[]>
+  ): void;
+  export function find(vid: number): Promise<Device[]>;
+  export function find(callback: (error: any, devices: Device[]) => any): void;
+  export function find(): Promise<Device[]>;
 
-  export function startMonitoring(): void
-  export function stopMonitoring(): void
-  export function on(event: string, callback: Function): void
-  export function off(event: string, callback: Function): void
+  export function startMonitoring(): void;
+  export function stopMonitoring(): void;
+  export function on(
+    event: string,
+    callback: (devices: Device[]) => void,
+  ): void;
+  export function off(
+    event: string,
+    callback: (devices: Device[]) => void,
+  ): void;
+  export function addListener(
+    event: string,
+    callback: (devices: Device[]) => void,
+  ): void;
+  export function removeListener(
+    event: string,
+    callback: (devices: Device[]) => void,
+  ): void;
 
-  export const version: number
+  export const version: number;
 }


### PR DESCRIPTION
Fixes #120 

Added a bare-bones integration test for devices and tested both `devices` and `printers` subscriptions in `about:blank` and `devices` in Election Manager. Requires this patch be applied in `vxsuite`:

```diff
diff --git a/libs/ui/src/hooks/use_devices.ts b/libs/ui/src/hooks/use_devices.ts
index 34a69360..c4828536 100644
--- a/libs/ui/src/hooks/use_devices.ts
+++ b/libs/ui/src/hooks/use_devices.ts
@@ -7,7 +7,6 @@ import {
   isPrecinctScanner,
 } from '@votingworks/utils';
 import { useEffect, useState } from 'react';
-import { map } from 'rxjs/operators';
 import useInterval from 'use-interval';
 import { useCancelablePromise } from './use_cancelable_promise';
 import { usePrevious } from './use_previous';
@@ -64,13 +63,13 @@ export function useDevices({ hardware, logger }: Props): Devices {
   const previousPrinters = usePrevious(allPrinters);
 
   useEffect(() => {
-    const hardwareStatusSubscription = hardware.devices
-      .pipe(map((devices) => Array.from(devices)))
-      .subscribe(setAllDevices);
+    const hardwareStatusSubscription = hardware.devices.subscribe((devices) => {
+      setAllDevices(Array.from(devices));
+    });
 
-    const printerStatusSubscription = hardware.printers
-      .pipe(map((printers) => Array.from(printers)))
-      .subscribe(setAllPrinters);
+    const printerStatusSubscription = hardware.printers.subscribe((devices) => {
+      setAllPrinters(Array.from(devices));
+    });
 
     return () => {
       hardwareStatusSubscription.unsubscribe();
```