### PR TITLE
add kiosk.rebootToBIOS()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import registerTotpGetHandler from './ipc/totp-get';
 import registerLogHandler from './ipc/log';
 import registerSignHandler from './ipc/sign';
 import registerRebootHandler from './ipc/reboot';
+import registerRebootToBIOSHandler from './ipc/reboot-to-bios';
 import registerPrepareBootUsb from './ipc/prepare-boot-usb';
 import parseOptions, { Options, printHelp } from './utils/options';
 import autoconfigurePrint from './utils/printing/autoconfigurePrinter';
@@ -130,6 +131,7 @@ async function createWindow(): Promise<void> {
     registerSignHandler,
     registerRebootHandler,
     registerPrepareBootUsb,
+    registerRebootToBIOSHandler,
   ];
 
   const handlerCleanups = handlers

--- a/src/ipc/reboot-to-bios.test.ts
+++ b/src/ipc/reboot-to-bios.test.ts
@@ -1,0 +1,25 @@
+import { fakeIpc } from '../../test/ipc';
+import register, { channel } from './reboot-to-bios';
+import mockOf from '../../test/mockOf';
+import exec from '../utils/exec';
+
+const execMock = mockOf(exec);
+jest.mock('../utils/exec');
+
+beforeEach(() => {
+  execMock.mockReset();
+  execMock.mockReturnValue({ stdout: '', stderr: '' });
+});
+
+test('reboot to bios', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc();
+
+  register(ipcMain);
+
+  await ipcRenderer.invoke(channel);
+  expect(execMock).toHaveBeenCalledTimes(1);
+  expect(execMock).toHaveBeenNthCalledWith(1, 'systemctl', [
+    'reboot',
+    '--firmware-setup',
+  ]);
+});

--- a/src/ipc/reboot-to-bios.ts
+++ b/src/ipc/reboot-to-bios.ts
@@ -1,0 +1,13 @@
+import { IpcMain } from 'electron';
+import exec from '../utils/exec';
+
+export const channel = 'reboot-to-bios';
+
+/**
+ * Reboot the machine
+ */
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(channel, () => {
+    exec('systemctl', ['reboot', '--firmware-setup']);
+  });
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -24,6 +24,7 @@ import { channel as printChannel } from './ipc/print';
 import { channel as printToPDFChannel } from './ipc/printToPDF';
 import { channel as quitChannel } from './ipc/quit';
 import { channel as rebootChannel } from './ipc/reboot';
+import { channel as rebootToBIOSChannel } from './ipc/reboot-to-bios';
 import { PromptToSaveOptions } from './ipc/saveAs';
 import { channel as signChannel, SignParams } from './ipc/sign';
 import { channel as storageClearChannel } from './ipc/storage-clear';
@@ -243,6 +244,11 @@ function makeKiosk(): KioskBrowser.Kiosk {
     async reboot(): Promise<void> {
       debug('forwarding `reboot` to the main process');
       await ipcRenderer.invoke(rebootChannel);
+    },
+
+    async rebootToBIOS(): Promise<void> {
+      debug('forwarding `rebootToBIOS` to the main process');
+      await ipcRenderer.invoke(rebootToBIOSChannel);
     },
   };
 }

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -237,6 +237,8 @@ declare namespace KioskBrowser {
 
     reboot(): Promise<void>;
 
+    rebootToBIOS(): Promise<void>;
+
     prepareToBootFromUsb(): Promise<boolean>;
   }
 }


### PR DESCRIPTION
As part of being able to update equipment in the field, the ability to reboot to BIOS is an important complement to "Reboot to USB".