### PR TITLE
add kiosk.syncUsbDrive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import registerStorageClearHandler from './ipc/storage-clear';
 import registerStorageGetHandler from './ipc/storage-get';
 import registerStorageRemoveHandler from './ipc/storage-remove';
 import registerStorageSetHandler from './ipc/storage-set';
+import registerSyncUsbDriveHandler from './ipc/sync-usb-drive';
 import registerUnmountUsbDriveHandler from './ipc/unmount-usb-drive';
 import registerTotpGetHandler from './ipc/totp-get';
 import registerLogHandler from './ipc/log';
@@ -121,6 +122,7 @@ async function createWindow(): Promise<void> {
     registerGetUsbDrivesHandler,
     registerMountUsbDriveHandler,
     registerUnmountUsbDriveHandler,
+    registerSyncUsbDriveHandler,
     registerStorageSetHandler,
     registerStorageGetHandler,
     registerStorageRemoveHandler,

--- a/src/ipc/sync-usb-drive.test.ts
+++ b/src/ipc/sync-usb-drive.test.ts
@@ -1,0 +1,26 @@
+import { IpcMain, IpcMainEvent } from 'electron';
+import mockOf from '../../test/mockOf';
+import promisifiedExec from '../utils/promisifiedExec';
+import register, { channel } from './sync-usb-drive';
+
+const promisifiedExecMock = mockOf(promisifiedExec);
+
+jest.mock('../utils/promisifiedExec');
+
+test('sync-usb-drive', async () => {
+  // Register our handler.
+  const handle = jest.fn<
+    ReturnType<IpcMain['handle']>,
+    Parameters<IpcMain['handle']>
+  >();
+  register({ handle } as unknown as IpcMain);
+
+  // Things should be registered as expected.
+  expect(handle).toHaveBeenCalledWith(channel, expect.any(Function));
+
+  // Is the handler wired up right?
+  const [, handler] = handle.mock.calls[0];
+  await handler({} as IpcMainEvent, '/media/vx/drive');
+
+  expect(promisifiedExecMock).toHaveBeenCalledWith('sync -f /media/vx/drive');
+});

--- a/src/ipc/sync-usb-drive.ts
+++ b/src/ipc/sync-usb-drive.ts
@@ -1,0 +1,17 @@
+import { IpcMain, IpcMainInvokeEvent } from 'electron';
+import promisifiedExec from '../utils/promisifiedExec';
+
+export const channel = 'syncUsbDrive';
+
+async function syncUsbDrive(mountPoint: string): Promise<void> {
+  await promisifiedExec(`sync -f ${mountPoint}`);
+}
+
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(
+    channel,
+    async (event: IpcMainInvokeEvent, mountPoint: string) => {
+      await syncUsbDrive(mountPoint);
+    },
+  );
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -33,6 +33,8 @@ import { channel as storageRemoveChannel } from './ipc/storage-remove';
 import { channel as storageSetChannel } from './ipc/storage-set';
 import { channel as totpGetChannel, TotpInfo } from './ipc/totp-get';
 import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive';
+import { channel as syncUsbDriveChannel } from './ipc/sync-usb-drive';
+
 import buildDevicesObservable from './utils/buildDevicesObservable';
 import buildPrinterInfoObservable from './utils/buildPrinterInfoObservable';
 import { FileWriter, fromPath, fromPrompt } from './utils/FileWriter';
@@ -110,6 +112,11 @@ function makeKiosk(): KioskBrowser.Kiosk {
     async unmountUsbDrive(device: string): Promise<void> {
       debug('forwarding `unmountUsbDrive` to main process');
       await ipcRenderer.invoke(unmountUsbDriveChannel, device);
+    },
+
+    async syncUsbDrive(mountPoint: string): Promise<void> {
+      debug('forwarding `syncUsbDrive` to main process');
+      await ipcRenderer.invoke(syncUsbDriveChannel, mountPoint);
     },
 
     async getFileSystemEntries(path: string): Promise<FileSystemEntry[]> {

--- a/src/utils/promisifiedExec.ts
+++ b/src/utils/promisifiedExec.ts
@@ -1,0 +1,5 @@
+import { promisify } from 'util';
+import { exec } from 'child_process';
+
+const promisifiedExec = promisify(exec);
+export default promisifiedExec;

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -207,6 +207,7 @@ declare namespace KioskBrowser {
     getUsbDrives(): Promise<UsbDrive[]>;
     mountUsbDrive(device: string): Promise<void>;
     unmountUsbDrive(device: string): Promise<void>;
+    syncUsbDrive(mountPoint: string): Promise<void>;
 
     /**
      * Reads the list of files at a specified directory path


### PR DESCRIPTION
Adds a new `kiosk-browser` API which allows us to trigger (and `await`) data to be flushed to the removable disk.