### PR TITLE
speak & cancelSpeak APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import registerUnmountUsbDriveHandler from './ipc/unmount-usb-drive';
 import registerTotpGetHandler from './ipc/totp-get';
 import registerLogHandler from './ipc/log';
 import registerSignHandler from './ipc/sign';
+import registerSpeakHandler from './ipc/speak';
+import registerCancelSpeakHandler from './ipc/cancel-speak';
 import registerRebootHandler from './ipc/reboot';
 import registerRebootToBiosHandler from './ipc/reboot-to-bios';
 import registerPrepareBootUsb from './ipc/prepare-boot-usb';
@@ -131,6 +133,8 @@ async function createWindow(): Promise<void> {
     registerTotpGetHandler,
     registerLogHandler,
     registerSignHandler,
+    registerSpeakHandler,
+    registerCancelSpeakHandler,
     registerRebootHandler,
     registerPrepareBootUsb,
     registerRebootToBiosHandler,

--- a/src/ipc/cancel-speak.test.ts
+++ b/src/ipc/cancel-speak.test.ts
@@ -1,0 +1,44 @@
+import { IpcMain, IpcMainEvent } from 'electron';
+import { fakeIpc } from '../../test/ipc';
+import mockOf from '../../test/mockOf';
+import deferred from '../../test/deferred';
+import exec from '../utils/exec';
+import register, { channel } from './cancel-speak';
+
+const execMock = mockOf(exec);
+
+jest.mock('../utils/exec');
+
+test('cancel-speak', async () => {
+  // Register our handler.
+  const handle = jest.fn<
+    ReturnType<IpcMain['handle']>,
+    Parameters<IpcMain['handle']>
+  >();
+  register({ handle } as unknown as IpcMain);
+
+  // Things should be registered as expected.
+  expect(handle).toHaveBeenCalledWith(channel, expect.any(Function));
+
+  // Is the handler wired up right?
+  const [, handler] = handle.mock.calls[0];
+  await handler({} as IpcMainEvent);
+
+  expect(execMock).toHaveBeenCalledWith('spd-say', ['-C']);
+});
+
+test('does not duplicate request to cancel speech if job already exists', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc();
+  register(ipcMain);
+
+  const { promise, resolve } = deferred<{ stdout: string; stderr: string }>();
+  execMock.mockReturnValueOnce(promise);
+
+  const firstCancel = ipcRenderer.invoke(channel);
+  const secondCancel = ipcRenderer.invoke(channel);
+  resolve({ stdout: '', stderr: '' });
+  await firstCancel;
+  await secondCancel;
+
+  expect(execMock).toBeCalledTimes(1);
+});

--- a/src/ipc/cancel-speak.ts
+++ b/src/ipc/cancel-speak.ts
@@ -1,0 +1,40 @@
+import makeDebug from 'debug';
+import { IpcMain } from 'electron';
+import exec from '../utils/exec';
+
+export const channel = 'cancelSpeak';
+
+const debug = makeDebug('kiosk-browser:speak');
+
+/**
+ * Sends request to speech-dispatcher to cancel all messages
+ * @returns promise representing call to `spd-say -C`
+ */
+async function cancelSpeak(): Promise<void> {
+  debug('cancelling all messages in speech dispatcher...');
+  try {
+    await exec('spd-say', ['-C']);
+    debug('cancelled all messages in speech dispatcher');
+  } catch (e) {
+    debug('failed to cancel messages in speech dispatcher with error %s', e);
+  }
+}
+
+export default function register(ipcMain: IpcMain): void {
+  /**
+   * If `cancelSpeak` is called several times in a row, the `spd-say` process
+   * will fail because the speech-dispatcher is already running. So in this
+   * method, we track the current request to cancel with `promiseToCancel` and
+   * only initiate a new request if necessary.
+   */
+  let promiseToCancel: Promise<void> | undefined = undefined;
+  ipcMain.handle(channel, async () => {
+    if (promiseToCancel) {
+      await promiseToCancel;
+    } else {
+      promiseToCancel = cancelSpeak();
+      await promiseToCancel;
+      promiseToCancel = undefined;
+    }
+  });
+}

--- a/src/ipc/speak.test.ts
+++ b/src/ipc/speak.test.ts
@@ -1,0 +1,50 @@
+import { IpcMain, IpcMainEvent } from 'electron';
+import { fakeIpc } from '../../test/ipc';
+import mockOf from '../../test/mockOf';
+import exec from '../utils/exec';
+import register, { channel } from './speak';
+
+const execMock = mockOf(exec);
+
+jest.mock('../utils/exec');
+
+beforeEach(() => {
+  execMock.mockReset();
+});
+
+test('speak', async () => {
+  // Register our handler.
+  const handle = jest.fn<
+    ReturnType<IpcMain['handle']>,
+    Parameters<IpcMain['handle']>
+  >();
+  register({ handle } as unknown as IpcMain);
+
+  // Things should be registered as expected.
+  expect(handle).toHaveBeenCalledWith(channel, expect.any(Function));
+  const [, handler] = handle.mock.calls[0];
+
+  await handler({} as IpcMainEvent, 'hello world', { volume: 67 });
+  // Calls amixer and passes our our provided volume.
+  expect(execMock).toHaveBeenNthCalledWith(1, 'amixer', [
+    '-q',
+    '-D',
+    'pulse',
+    'sset',
+    'Master',
+    '67%',
+  ]);
+  // Calls spd-say with our provided text.
+  expect(execMock).toHaveBeenNthCalledWith(2, 'spd-say', ['-w', 'hello world']);
+});
+
+test('throws error if called with invalid volume setting', async () => {
+  const { ipcMain, ipcRenderer } = fakeIpc();
+  register(ipcMain);
+
+  await expect(
+    ipcRenderer.invoke(channel, 'hello world', { volume: 120 }),
+  ).rejects.toThrowError();
+
+  expect(execMock).not.toHaveBeenCalled();
+});

--- a/src/ipc/speak.ts
+++ b/src/ipc/speak.ts
@@ -1,0 +1,62 @@
+import makeDebug from 'debug';
+import { IpcMain, IpcMainInvokeEvent } from 'electron';
+import exec from '../utils/exec';
+
+export const channel = 'speak';
+
+const debug = makeDebug('kiosk-browser:speak');
+
+export interface Options {
+  volume: number;
+}
+
+async function setVolume(volume: number) {
+  if (volume >= 0 && volume <= 100) {
+    try {
+      await exec('amixer', [
+        '-q',
+        '-D',
+        'pulse',
+        'sset',
+        'Master',
+        `${volume}%`,
+      ]);
+      debug('volume set to %d%%', volume);
+    } catch (e) {
+      debug('failed to set volume to %d%% with error %s', volume, e);
+    }
+  } else {
+    throw new Error('volume setting must be between 0 and 100, inclusive.');
+  }
+}
+
+/**
+ * Sends text to the speech-dispatcher via `spd-say`. Returns a promise which
+ * resolves when `spd-say` exits, meaning the text was fully spoken or the
+ * speech-dispatcher was cleared or interrupted by another request.
+ * @param text The text to be spoken
+ * @param volume Number between 0-100
+ * @returns promise representing call to `spd-say`
+ */
+async function speak(text: string, { volume }: Options): Promise<void> {
+  // Set the audio volume before every utterance
+  await setVolume(volume);
+
+  debug('sending text "%s" to speech dispatcher...', text);
+  try {
+    // -w flag makes spd-say wait until speaking is complete
+    await exec('spd-say', ['-w', text]);
+    debug('request to read text "%s" resolved by speech dispatcher', text);
+  } catch (e) {
+    debug('failed to send message to speech dispatcher with error %s', e);
+  }
+}
+
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(
+    channel,
+    async (event: IpcMainInvokeEvent, text: string, options: Options) => {
+      await speak(text, options);
+    },
+  );
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,7 @@
 import makeDebug from 'debug';
 import { contextBridge, ipcRenderer } from 'electron';
 import { MakeDirectoryOptions } from 'fs';
+import { channel as cancelSpeakChannel } from './ipc/cancel-speak';
 import { channel as setClockChannel } from './ipc/clock';
 import {
   channel as fileSystemGetEntriesChannel,
@@ -33,6 +34,7 @@ import { channel as storageRemoveChannel } from './ipc/storage-remove';
 import { channel as storageSetChannel } from './ipc/storage-set';
 import { channel as totpGetChannel, TotpInfo } from './ipc/totp-get';
 import { channel as unmountUsbDriveChannel } from './ipc/unmount-usb-drive';
+import { channel as speakChannel, Options as SpeakOptions } from './ipc/speak';
 import { channel as syncUsbDriveChannel } from './ipc/sync-usb-drive';
 
 import buildDevicesObservable from './utils/buildDevicesObservable';
@@ -204,6 +206,16 @@ function makeKiosk(): KioskBrowser.Kiosk {
     async sign(params: SignParams): Promise<string> {
       debug('forwarding `sign` to main process');
       return (await ipcRenderer.invoke(signChannel, params)) as string;
+    },
+
+    async speak(utterance: string, options: SpeakOptions): Promise<void> {
+      debug('forwarding `speak` to main process');
+      await ipcRenderer.invoke(speakChannel, utterance, options);
+    },
+
+    async cancelSpeak(): Promise<void> {
+      debug('forwarding `cancelSpeak` to main process');
+      await ipcRenderer.invoke(cancelSpeakChannel);
     },
 
     async prepareToBootFromUsb(): Promise<boolean> {

--- a/test/deferred.ts
+++ b/test/deferred.ts
@@ -1,0 +1,32 @@
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason: unknown): void;
+}
+
+/**
+ * Builds a deferred promise that separates the promise itself from the resolve
+ * and reject functions, allowing easily passing a promise elsewhere for easy
+ * resolution later.
+ *
+ * @example
+ *
+ * const { promise, resolve, reject } = deferred<number>()
+ * giveThePromiseToSomeone(promise)
+ * computeAThingWithACallback((value) => {
+ *   if (typeof value === 'number') {
+ *     resolve(value)
+ *   } else {
+ *     reject(new Error('computation failed'))
+ *   }
+ * })
+ */
+export default function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -171,6 +171,10 @@ declare namespace KioskBrowser {
     subscribe(callback: (value: T) => void): () => void;
   }
 
+  export interface SpeakOptions {
+    volume: number;
+  }
+
   export interface Kiosk {
     print(options?: PrintOptions): Promise<void>;
     getPrinterInfo(): Promise<PrinterInfo[]>;
@@ -235,6 +239,9 @@ declare namespace KioskBrowser {
     };
 
     sign(params: SignParams): Promise<string>;
+
+    speak(text: string, options: SpeakOptions): Promise<void>;
+    cancelSpeak(): Promise<void>;
 
     reboot(): Promise<void>;
 


### PR DESCRIPTION
Adds a `speak` and `cancelSpeak` API to use Linux's speech-dispatcher via `spd-say`. 