### PR TITLE
Async Exec Alternative

### DIFF
--- a/src/ipc/clock.test.ts
+++ b/src/ipc/clock.test.ts
@@ -1,14 +1,14 @@
 import { fakeIpc } from '../../test/ipc';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import register, { channel as setClockChannel } from './clock';
 
-const execMock = mockOf(exec);
-jest.mock('../utils/exec');
+const execSyncMock = mockOf(execSync);
+jest.mock('../utils/execSync');
 
 beforeEach(() => {
-  execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execSyncMock.mockReset();
+  execSyncMock.mockReturnValue({ stdout: '', stderr: '' });
 });
 
 const { ipcMain, ipcRenderer } = fakeIpc();
@@ -20,14 +20,14 @@ test('set datetime works in daylights savings', async () => {
     IANAZone: 'America/Chicago',
   });
 
-  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     'timedatectl',
     'set-timezone',
     'America/Chicago',
   ]);
 
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     'timedatectl',
     'set-time',
@@ -41,14 +41,14 @@ test('set datetime works in non- daylights savings', async () => {
     IANAZone: 'America/Chicago',
   });
 
-  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     'timedatectl',
     'set-timezone',
     'America/Chicago',
   ]);
 
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     'timedatectl',
     'set-time',
@@ -57,7 +57,7 @@ test('set datetime works in non- daylights savings', async () => {
 });
 
 test('set datetime fails when NTP is enabled', async () => {
-  execMock.mockImplementationOnce(() => {
+  execSyncMock.mockImplementationOnce(() => {
     throw new Error(
       'Failed to set time: Automatic time synchronization is enabled',
     );

--- a/src/ipc/clock.ts
+++ b/src/ipc/clock.ts
@@ -1,6 +1,6 @@
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { DateTime } from 'luxon';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'setClock';
 
@@ -11,8 +11,8 @@ function clockSet({
   const datetimeString = DateTime.fromISO(isoDatetime, {
     zone: IANAZone,
   }).toFormat('yyyy-LL-dd TT');
-  exec('sudo', ['-n', 'timedatectl', 'set-timezone', IANAZone]);
-  exec('sudo', ['-n', 'timedatectl', 'set-time', datetimeString]);
+  execSync('sudo', ['-n', 'timedatectl', 'set-timezone', IANAZone]);
+  execSync('sudo', ['-n', 'timedatectl', 'set-time', datetimeString]);
 }
 
 export default function register(ipcMain: IpcMain): void {

--- a/src/ipc/get-printer-info.test.ts
+++ b/src/ipc/get-printer-info.test.ts
@@ -12,10 +12,10 @@ import register, {
   channel as getPrinterInfoChannel,
   getPrinterInfo,
 } from './get-printer-info';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 jest.mock('../utils/printing/getConnectedDeviceURIs');
-jest.mock('../utils/exec');
+jest.mock('../utils/execSync');
 
 describe('getPrinterInfo', () => {
   it('expands the printer info with connected=true if lpinfo shows the device', () => {
@@ -71,7 +71,7 @@ describe('getPrinterInfo', () => {
     mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
-    mockOf(exec).mockReturnValue({
+    mockOf(execSync).mockReturnValue({
       stdout: fakeIpptoolStdout(),
       stderr: '',
     });
@@ -108,7 +108,7 @@ describe('getPrinterInfo', () => {
     mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
-    mockOf(exec).mockImplementation(() => {
+    mockOf(execSync).mockImplementation(() => {
       throw new Error('ipptool failed');
     });
 
@@ -133,7 +133,7 @@ describe('getPrinterInfo', () => {
     mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
-    mockOf(exec)
+    mockOf(execSync)
       .mockImplementationOnce(() => {
         throw new Error('ipptool failed');
       })

--- a/src/ipc/get-usb-drives.test.ts
+++ b/src/ipc/get-usb-drives.test.ts
@@ -1,10 +1,10 @@
 import { IpcMain, IpcMainEvent } from 'electron';
 import { promises as fs } from 'fs';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import register, { channel, UsbDrive } from './get-usb-drives';
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 const accessMock = fs.access as unknown as jest.Mock<Promise<void>>;
 const readdirMock = fs.readdir as unknown as jest.Mock<Promise<string[]>>;
 const readlinkMock = fs.readlink as unknown as jest.Mock<Promise<string>>;
@@ -16,7 +16,7 @@ jest.mock('fs', () => ({
     readlink: jest.fn(),
   },
 }));
-jest.mock('../utils/exec');
+jest.mock('../utils/execSync');
 
 test('get-usb-drives', async () => {
   // Register our handler.
@@ -36,7 +36,7 @@ test('get-usb-drives', async () => {
   ]);
   readlinkMock.mockResolvedValueOnce('../../sdb1');
   readlinkMock.mockResolvedValueOnce('../../sdc1');
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: JSON.stringify({
       blockdevices: [
         {
@@ -52,7 +52,7 @@ test('get-usb-drives', async () => {
     }),
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: JSON.stringify({
       blockdevices: [
         {
@@ -69,7 +69,7 @@ test('get-usb-drives', async () => {
     stderr: '',
   });
 
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: JSON.stringify({
       filesystems: [
         {
@@ -95,8 +95,8 @@ test('get-usb-drives', async () => {
   const [, handler] = handle.mock.calls[0];
   const devices = (await handler({} as IpcMainEvent)) as UsbDrive[];
 
-  expect(execMock).toHaveBeenCalledTimes(4);
-  expect(execMock).toHaveBeenNthCalledWith(4, 'pumount', [
+  expect(execSyncMock).toHaveBeenCalledTimes(4);
+  expect(execSyncMock).toHaveBeenNthCalledWith(4, 'pumount', [
     '/media/usb-drive-sdz1',
   ]);
   expect(devices).toEqual([
@@ -118,7 +118,7 @@ test('get-usb-drives works when findmnt returns nothing', async () => {
 
   readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
   readlinkMock.mockResolvedValueOnce('../../sdb1');
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: JSON.stringify({
       blockdevices: [
         {
@@ -135,7 +135,7 @@ test('get-usb-drives works when findmnt returns nothing', async () => {
     stderr: '',
   });
 
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -144,8 +144,8 @@ test('get-usb-drives works when findmnt returns nothing', async () => {
   const [, handler] = handle.mock.calls[0];
   const devices = (await handler({} as IpcMainEvent)) as UsbDrive[];
 
-  expect(execMock).toHaveBeenCalledTimes(2);
-  expect(execMock).toHaveBeenCalledWith('findmnt', ['--json', '--list']);
+  expect(execSyncMock).toHaveBeenCalledTimes(2);
+  expect(execSyncMock).toHaveBeenCalledWith('findmnt', ['--json', '--list']);
   expect(devices).toEqual([
     { deviceName: 'sdb1', mountPoint: '/media/usb-drive-sdb1' },
   ]);

--- a/src/ipc/get-usb-drives.ts
+++ b/src/ipc/get-usb-drives.ts
@@ -2,7 +2,7 @@ import makeDebug from 'debug';
 import { IpcMain } from 'electron';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 const debug = makeDebug('kiosk-browser:get-usb-drives');
 
@@ -54,7 +54,7 @@ async function getUsbDrives(): Promise<UsbDrive[]> {
 
     // get the block device info, including mount point
     const usbDrives = devices.map((device) => {
-      const { stdout } = exec('lsblk', ['-J', '-n', '-l', device]);
+      const { stdout } = execSync('lsblk', ['-J', '-n', '-l', device]);
 
       const rawData = JSON.parse(stdout) as RawDataReturn;
       return {
@@ -64,7 +64,7 @@ async function getUsbDrives(): Promise<UsbDrive[]> {
     });
 
     // Find any phantom usb drives that were improperly removed and need to be unmounted
-    const { stdout } = exec('findmnt', ['--json', '--list']);
+    const { stdout } = execSync('findmnt', ['--json', '--list']);
     if (stdout !== '') {
       const rawData = JSON.parse(stdout) as FindMntRawDataReturn;
       await Promise.all(
@@ -78,7 +78,7 @@ async function getUsbDrives(): Promise<UsbDrive[]> {
                 target,
                 source,
               );
-              exec('pumount', [target]);
+              execSync('pumount', [target]);
             }
           }
         }),

--- a/src/ipc/mount-usb-drive.test.ts
+++ b/src/ipc/mount-usb-drive.test.ts
@@ -1,11 +1,11 @@
 import { fakeIpc } from '../../test/ipc';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import register, { channel } from './mount-usb-drive';
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
-jest.mock('../utils/exec');
+jest.mock('../utils/execSync');
 
 test('mount-usb-drive', async () => {
   // Register our handler.
@@ -13,7 +13,7 @@ test('mount-usb-drive', async () => {
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -21,7 +21,7 @@ test('mount-usb-drive', async () => {
   // Is the handler wired up right?
   await ipcRenderer.invoke(channel, { device: 'sdb1' });
 
-  expect(execMock).toHaveBeenCalledWith('pmount', [
+  expect(execSyncMock).toHaveBeenCalledWith('pmount', [
     '-w',
     '-u',
     '000',
@@ -36,7 +36,7 @@ test('mount-usb-drive with custom label', async () => {
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -44,7 +44,7 @@ test('mount-usb-drive with custom label', async () => {
   // Is the handler wired up right?
   await ipcRenderer.invoke(channel, { device: 'sdb1', label: 'usb-drive' });
 
-  expect(execMock).toHaveBeenCalledWith('pmount', [
+  expect(execSyncMock).toHaveBeenCalledWith('pmount', [
     '-w',
     '-u',
     '000',

--- a/src/ipc/mount-usb-drive.ts
+++ b/src/ipc/mount-usb-drive.ts
@@ -1,6 +1,6 @@
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { join } from 'path';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'mountUsbDrive';
 
@@ -10,7 +10,7 @@ export interface Options {
 }
 
 function mountUsbDrive(options: Options): void {
-  exec('pmount', [
+  execSync('pmount', [
     '-w',
     '-u',
     '000',

--- a/src/ipc/prepare-boot-usb.test.ts
+++ b/src/ipc/prepare-boot-usb.test.ts
@@ -1,14 +1,14 @@
 import { fakeIpc } from '../../test/ipc';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import register, { channel } from './prepare-boot-usb';
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
-jest.mock('../utils/exec');
+jest.mock('../utils/execSync');
 
 beforeEach(() => {
-  execMock.mockClear();
+  execSyncMock.mockClear();
 });
 
 test('prepare-boot-usb returns false when no bootable usbs', async () => {
@@ -17,7 +17,7 @@ test('prepare-boot-usb returns false when no bootable usbs', async () => {
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: `BootCurrent: 0005
 Timeout: 0 seconds
 BootOrder: 0005,0002,0001,0003,0000,0004
@@ -35,8 +35,8 @@ Boot0005* debian	HD(1,GPT,7dd453ac-2e62-44f6-be51-5f6bcaa85a61,0x800,0x100000)/F
   const result = (await ipcRenderer.invoke(channel)) as boolean;
   expect(result).toBe(false);
 
-  expect(execMock).toBeCalledTimes(1);
-  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
+  expect(execSyncMock).toBeCalledTimes(1);
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
 });
 
 test('prepare-boot-usb returns true when expected and sets correct boot order', async () => {
@@ -45,7 +45,7 @@ test('prepare-boot-usb returns true when expected and sets correct boot order', 
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
@@ -57,7 +57,7 @@ Boot2003* EFI Network	RC
        `,
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -65,9 +65,9 @@ Boot2003* EFI Network	RC
   // Is the handler wired up right?
   const result = (await ipcRenderer.invoke(channel)) as boolean;
   expect(result).toBe(true);
-  expect(execMock).toBeCalledTimes(2);
-  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+  expect(execSyncMock).toBeCalledTimes(2);
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
+  expect(execSyncMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     '/bin/efibootmgr',
     '-n',
@@ -81,7 +81,7 @@ test('prepare-boot-usb returns true with a USB HDD entry that has a GPT partitio
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
@@ -92,7 +92,7 @@ Boot2003* EFI Network	RC
        `,
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -100,9 +100,9 @@ Boot2003* EFI Network	RC
   // Is the handler wired up right?
   const result = (await ipcRenderer.invoke(channel)) as boolean;
   expect(result).toBe(true);
-  expect(execMock).toBeCalledTimes(2);
-  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+  expect(execSyncMock).toBeCalledTimes(2);
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
+  expect(execSyncMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     '/bin/efibootmgr',
     '-n',
@@ -116,7 +116,7 @@ test('prepare-boot-usb returns true when there is a fallback Boot Menu option', 
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
@@ -128,7 +128,7 @@ Boot200E  Boot Menu	RC
        `,
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -136,9 +136,9 @@ Boot200E  Boot Menu	RC
   // Is the handler wired up right?
   const result = (await ipcRenderer.invoke(channel)) as boolean;
   expect(result).toBe(true);
-  expect(execMock).toBeCalledTimes(2);
-  expect(execMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
-  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+  expect(execSyncMock).toBeCalledTimes(2);
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'efibootmgr', ['-v']);
+  expect(execSyncMock).toHaveBeenNthCalledWith(2, 'sudo', [
     '-n',
     '/bin/efibootmgr',
     '-n',

--- a/src/ipc/prepare-boot-usb.ts
+++ b/src/ipc/prepare-boot-usb.ts
@@ -1,6 +1,6 @@
 import makeDebug from 'debug';
 import { IpcMain } from 'electron';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'prepare-boot-usb';
 const debug = makeDebug('kiosk-browser:prepare-boot-usb');
@@ -51,7 +51,7 @@ function parseEfiBootMgrOutput(output: string): BootOption[] {
  * if successful, returns false if there are either 0 or more then 1 bootable usb drives available.
  */
 function prepareToBootFromUsb(): boolean {
-  const { stdout: bootStdout } = exec('efibootmgr', ['-v']);
+  const { stdout: bootStdout } = execSync('efibootmgr', ['-v']);
   const bootOptions = parseEfiBootMgrOutput(bootStdout);
   const linpusBootOption = bootOptions.find((bootOption) =>
     bootOption.restOfEntry.includes('Linpus'),
@@ -71,7 +71,7 @@ function prepareToBootFromUsb(): boolean {
   debug(
     'The USB boot option was properly located setting it to be next in the boot order…',
   );
-  exec('sudo', ['-n', '/bin/efibootmgr', '-n', nextBoot.bootNumber]);
+  execSync('sudo', ['-n', '/bin/efibootmgr', '-n', nextBoot.bootNumber]);
   return true;
 }
 

--- a/src/ipc/print.test.ts
+++ b/src/ipc/print.test.ts
@@ -2,19 +2,19 @@ import { WebContents } from 'electron';
 import { fakeElectronPrinter } from '../../test/fakePrinter';
 import { fakeIpc } from '../../test/ipc';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import getPreferredPrinter from '../utils/getPreferredPrinter';
 import register, { channel as printChannel, PrintSides } from './print';
 
 const getPreferredPrinterMock = mockOf(getPreferredPrinter);
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
-jest.mock('../utils/exec');
+jest.mock('../utils/execSync');
 jest.mock('../utils/getPreferredPrinter', () => jest.fn());
 
 beforeEach(() => {
   getPreferredPrinterMock.mockReset();
-  execMock.mockReset();
+  execSyncMock.mockReset();
 });
 
 test('registers a handler to trigger a print', async () => {
@@ -26,7 +26,7 @@ test('registers a handler to trigger a print', async () => {
 
   register(ipcMain);
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, {
     deviceName: 'mainprinter',
@@ -37,7 +37,7 @@ test('registers a handler to trigger a print', async () => {
     printBackground: true,
   });
 
-  expect(execMock).toHaveBeenCalledWith(
+  expect(execSyncMock).toHaveBeenCalledWith(
     'lpr',
     ['-P', 'mainprinter', '-o', 'sides=two-sided-long-edge', 'InputSlot=Tray3'],
     expect.anything(),
@@ -57,13 +57,13 @@ test('uses the preferred printer if none is provided', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel);
 
   expect(sender.printToPDF).toHaveBeenCalledWith({ printBackground: true });
 
-  expect(execMock).toHaveBeenCalledWith(
+  expect(execSyncMock).toHaveBeenCalledWith(
     'lpr',
     ['-P', 'main printer', '-o', 'sides=two-sided-long-edge'],
     expect.anything(),
@@ -98,13 +98,13 @@ test('prints a specified number of copies', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, { copies: 123 });
 
   expect(sender.printToPDF).toHaveBeenCalledWith({ printBackground: true });
 
-  expect(execMock).toHaveBeenCalledWith(
+  expect(execSyncMock).toHaveBeenCalledWith(
     'lpr',
     ['-P', 'main printer', '-o', 'sides=two-sided-long-edge', '-#', '123'],
     expect.anything(),
@@ -124,14 +124,14 @@ test('does not allow fractional copies', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
 
   await expect(
     ipcRenderer.invoke(printChannel, { copies: 1.23 }),
   ).rejects.toThrowError();
 
   expect(sender.printToPDF).not.toHaveBeenCalled();
-  expect(execMock).not.toHaveBeenCalled();
+  expect(execSyncMock).not.toHaveBeenCalled();
 });
 
 test('allows specifying one-sided duplex', async () => {
@@ -147,11 +147,11 @@ test('allows specifying one-sided duplex', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, { sides: PrintSides.OneSided });
 
-  expect(execMock).toHaveBeenCalledWith(
+  expect(execSyncMock).toHaveBeenCalledWith(
     'lpr',
     ['-P', 'main printer', '-o', 'sides=one-sided'],
     expect.anything(),
@@ -171,13 +171,13 @@ test('allows specifying two-sided-short-edge duplex', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execSyncMock.mockReturnValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, {
     sides: PrintSides.TwoSidedShortEdge,
   });
 
-  expect(execMock).toHaveBeenCalledWith(
+  expect(execSyncMock).toHaveBeenCalledWith(
     'lpr',
     ['-P', 'main printer', '-o', 'sides=two-sided-short-edge'],
     expect.anything(),

--- a/src/ipc/print.ts
+++ b/src/ipc/print.ts
@@ -1,6 +1,6 @@
 import { IpcMain, IpcMainInvokeEvent, PrinterInfo } from 'electron';
 import * as z from 'zod';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import getPreferredPrinter from '../utils/getPreferredPrinter';
 import { debug } from '../utils/printing';
 
@@ -86,7 +86,7 @@ function printData({
 
   debug('printing via lpr with args=%o', lprOptions);
   debug('data length is %d', data.length);
-  const { stdout, stderr } = exec('lpr', lprOptions, data);
+  const { stdout, stderr } = execSync('lpr', lprOptions, data);
   debug('`lpr` succeeded with stdout=%s stderr=%s', stdout, stderr);
 }
 

--- a/src/ipc/reboot-to-bios.test.ts
+++ b/src/ipc/reboot-to-bios.test.ts
@@ -1,14 +1,14 @@
 import { fakeIpc } from '../../test/ipc';
 import register, { channel } from './reboot-to-bios';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
-const execMock = mockOf(exec);
-jest.mock('../utils/exec');
+const execSyncMock = mockOf(execSync);
+jest.mock('../utils/execSync');
 
 beforeEach(() => {
-  execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execSyncMock.mockReset();
+  execSyncMock.mockReturnValue({ stdout: '', stderr: '' });
 });
 
 test('reboot to bios', async () => {
@@ -17,8 +17,8 @@ test('reboot to bios', async () => {
   register(ipcMain);
 
   await ipcRenderer.invoke(channel);
-  expect(execMock).toHaveBeenCalledTimes(1);
-  expect(execMock).toHaveBeenNthCalledWith(1, 'systemctl', [
+  expect(execSyncMock).toHaveBeenCalledTimes(1);
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'systemctl', [
     'reboot',
     '--firmware-setup',
   ]);

--- a/src/ipc/reboot-to-bios.ts
+++ b/src/ipc/reboot-to-bios.ts
@@ -1,5 +1,5 @@
 import { IpcMain } from 'electron';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'reboot-to-bios';
 
@@ -8,6 +8,6 @@ export const channel = 'reboot-to-bios';
  */
 export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(channel, () => {
-    exec('systemctl', ['reboot', '--firmware-setup']);
+    execSync('systemctl', ['reboot', '--firmware-setup']);
   });
 }

--- a/src/ipc/reboot.test.ts
+++ b/src/ipc/reboot.test.ts
@@ -1,14 +1,14 @@
 import { fakeIpc } from '../../test/ipc';
 import register, { channel } from './reboot';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
-const execMock = mockOf(exec);
-jest.mock('../utils/exec');
+const execSyncMock = mockOf(execSync);
+jest.mock('../utils/execSync');
 
 beforeEach(() => {
-  execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execSyncMock.mockReset();
+  execSyncMock.mockReturnValue({ stdout: '', stderr: '' });
 });
 
 test('reboot', async () => {
@@ -17,5 +17,5 @@ test('reboot', async () => {
   register(ipcMain);
 
   await ipcRenderer.invoke(channel);
-  expect(execMock).toHaveBeenCalledTimes(1);
+  expect(execSyncMock).toHaveBeenCalledTimes(1);
 });

--- a/src/ipc/reboot.ts
+++ b/src/ipc/reboot.ts
@@ -1,5 +1,5 @@
 import { IpcMain } from 'electron';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'reboot';
 
@@ -8,6 +8,6 @@ export const channel = 'reboot';
  */
 export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(channel, () => {
-    exec('reboot');
+    execSync('reboot');
   });
 }

--- a/src/ipc/sign.ts
+++ b/src/ipc/sign.ts
@@ -1,7 +1,7 @@
 import makeDebug from 'debug';
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { RegisterIpcHandler } from '..';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'sign';
 
@@ -29,7 +29,7 @@ function sign(
   const rawPayloadToSign = `${signatureType}.${payload}`;
 
   try {
-    const { stdout, stderr } = exec(
+    const { stdout, stderr } = execSync(
       // TODO this feels really dangerous, is there a better way?
       signingScriptPath,
       [],

--- a/src/ipc/sync-usb-drive.test.ts
+++ b/src/ipc/sync-usb-drive.test.ts
@@ -3,7 +3,7 @@ import mockOf from '../../test/mockOf';
 import promisifiedExec from '../utils/promisifiedExec';
 import register, { channel } from './sync-usb-drive';
 
-const promisifiedExecMock = mockOf(promisifiedExec);
+const promisifiedexecSyncMock = mockOf(promisifiedExec);
 
 jest.mock('../utils/promisifiedExec');
 
@@ -22,5 +22,7 @@ test('sync-usb-drive', async () => {
   const [, handler] = handle.mock.calls[0];
   await handler({} as IpcMainEvent, '/media/vx/drive');
 
-  expect(promisifiedExecMock).toHaveBeenCalledWith('sync -f /media/vx/drive');
+  expect(promisifiedexecSyncMock).toHaveBeenCalledWith(
+    'sync -f /media/vx/drive',
+  );
 });

--- a/src/ipc/sync-usb-drive.test.ts
+++ b/src/ipc/sync-usb-drive.test.ts
@@ -1,11 +1,11 @@
 import { IpcMain, IpcMainEvent } from 'electron';
 import mockOf from '../../test/mockOf';
-import promisifiedExec from '../utils/promisifiedExec';
+import exec from '../utils/exec';
 import register, { channel } from './sync-usb-drive';
 
-const promisifiedexecSyncMock = mockOf(promisifiedExec);
+const execMock = mockOf(exec);
 
-jest.mock('../utils/promisifiedExec');
+jest.mock('../utils/exec');
 
 test('sync-usb-drive', async () => {
   // Register our handler.
@@ -22,7 +22,5 @@ test('sync-usb-drive', async () => {
   const [, handler] = handle.mock.calls[0];
   await handler({} as IpcMainEvent, '/media/vx/drive');
 
-  expect(promisifiedexecSyncMock).toHaveBeenCalledWith(
-    'sync -f /media/vx/drive',
-  );
+  expect(execMock).toHaveBeenCalledWith('sync', ['-f', '/media/vx/drive']);
 });

--- a/src/ipc/sync-usb-drive.ts
+++ b/src/ipc/sync-usb-drive.ts
@@ -1,10 +1,10 @@
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
-import promisifiedExec from '../utils/promisifiedExec';
+import exec from '../utils/exec';
 
 export const channel = 'syncUsbDrive';
 
 async function syncUsbDrive(mountPoint: string): Promise<void> {
-  await promisifiedExec(`sync -f ${mountPoint}`);
+  await exec('sync', ['-f', mountPoint]);
 }
 
 export default function register(ipcMain: IpcMain): void {

--- a/src/ipc/totp-get.test.ts
+++ b/src/ipc/totp-get.test.ts
@@ -1,28 +1,28 @@
 import { fakeIpc } from '../../test/ipc';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import register, { channel as totpGetChannel, TotpInfo } from './totp-get';
 
-const execMock = mockOf(exec);
-jest.mock('../utils/exec');
+const execSyncMock = mockOf(execSync);
+jest.mock('../utils/execSync');
 
 beforeEach(() => {
-  execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execSyncMock.mockReset();
+  execSyncMock.mockReturnValue({ stdout: '', stderr: '' });
 });
 
 const { ipcMain, ipcRenderer } = fakeIpc();
 register(ipcMain);
 
 test('call to totp calls appropriate shell command and returns the right data', async () => {
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '2021-09-10 14:35:02: 932549',
     stderr: '',
   });
 
   const totpResult = (await ipcRenderer.invoke(totpGetChannel)) as TotpInfo;
 
-  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     '/usr/local/bin/tpm2-totp',
     '-t',
@@ -37,15 +37,15 @@ test('call to totp calls appropriate shell command and returns the right data', 
   });
 });
 
-test('when error in exec, return undefined', async () => {
-  execMock.mockReturnValueOnce({
+test('when error in execSync, return undefined', async () => {
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: 'TPM is nowhere to be found',
   });
 
   const totpResult = (await ipcRenderer.invoke(totpGetChannel)) as TotpInfo;
 
-  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     '/usr/local/bin/tpm2-totp',
     '-t',
@@ -55,14 +55,14 @@ test('when error in exec, return undefined', async () => {
   expect(totpResult).toEqual(undefined);
 });
 
-test('when exec throws, return undefined', async () => {
-  execMock.mockImplementation(() => {
+test('when execSync throws, return undefined', async () => {
+  execSyncMock.mockImplementation(() => {
     throw new Error("I don't know what's going on");
   });
 
   const totpResult = (await ipcRenderer.invoke(totpGetChannel)) as TotpInfo;
 
-  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+  expect(execSyncMock).toHaveBeenNthCalledWith(1, 'sudo', [
     '-n',
     '/usr/local/bin/tpm2-totp',
     '-t',

--- a/src/ipc/totp-get.ts
+++ b/src/ipc/totp-get.ts
@@ -1,6 +1,6 @@
 import makeDebug from 'debug';
 import { IpcMain } from 'electron';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'totpGet';
 
@@ -13,7 +13,7 @@ export interface TotpInfo {
 
 function totpGet(): TotpInfo | undefined {
   try {
-    const { stdout, stderr } = exec('sudo', [
+    const { stdout, stderr } = execSync('sudo', [
       '-n',
       '/usr/local/bin/tpm2-totp',
       '-t',

--- a/src/ipc/unmount-usb-drive.test.ts
+++ b/src/ipc/unmount-usb-drive.test.ts
@@ -1,11 +1,11 @@
 import { IpcMain, IpcMainEvent } from 'electron';
 import mockOf from '../../test/mockOf';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 import register, { channel } from './unmount-usb-drive';
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
-jest.mock('../utils/exec');
+jest.mock('../utils/execSync');
 
 test('mount-usb-drive', async () => {
   // Register our handler.
@@ -18,7 +18,7 @@ test('mount-usb-drive', async () => {
   // Things should be registered as expected.
   expect(handle).toHaveBeenCalledWith(channel, expect.any(Function));
 
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -27,5 +27,5 @@ test('mount-usb-drive', async () => {
   const [, handler] = handle.mock.calls[0];
   await handler({} as IpcMainEvent, 'sdb1');
 
-  expect(execMock).toHaveBeenCalledWith('pumount', ['/dev/sdb1']);
+  expect(execSyncMock).toHaveBeenCalledWith('pumount', ['/dev/sdb1']);
 });

--- a/src/ipc/unmount-usb-drive.ts
+++ b/src/ipc/unmount-usb-drive.ts
@@ -1,11 +1,11 @@
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
 import { join } from 'path';
-import exec from '../utils/exec';
+import execSync from '../utils/execSync';
 
 export const channel = 'unmountUsbDrive';
 
 function unmountUsbDrive(device: string): void {
-  exec('pumount', [join('/dev', device)]);
+  execSync('pumount', [join('/dev', device)]);
 }
 
 export default function register(ipcMain: IpcMain): void {

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,0 +1,28 @@
+import child_process, { spawn } from 'child_process';
+import exec from './exec';
+
+jest.spyOn(child_process, 'spawn');
+
+test('command with no args', async () => {
+  const execPromise = exec('echo');
+  expect(spawn).toHaveBeenCalledWith('echo', []);
+  await expect(execPromise).resolves.toEqual(undefined);
+});
+
+test('command with args', async () => {
+  const execPromise = exec('echo', ['hi']);
+  expect(spawn).toHaveBeenCalledWith('echo', ['hi']);
+  await expect(execPromise).resolves.toEqual(undefined);
+});
+
+test('command that does not exist', async () => {
+  const execPromise = exec('not-a-command');
+  await expect(execPromise).rejects.toThrow('spawn not-a-command ENOENT');
+});
+
+test('command which exits with 1', async () => {
+  const execPromise = exec('false');
+  await expect(execPromise).rejects.toThrow(
+    'Error: Command failed: false  (stdout= stderr=)',
+  );
+});

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,0 +1,53 @@
+import { spawn } from 'child_process';
+import makeDebug from 'debug';
+import { makeExecError } from './execTypes';
+
+const debug = makeDebug('kiosk-browser:exec:async');
+
+/**
+ * The native `child_process.exec` function does not do input sanitization so
+ * is vulnerable to injection attacks. This implementation uses
+ * `child_process.spawn` under the hood, which does sanitize input.
+ *
+ * This implementation does not provide stdout or stderr. It is possible but
+ * difficult to test for. If you need stdout or stderr, use our `execSync`. If
+ * needed, this method can be augmented to return `Promise<ExecResult>`.
+ */
+export default function exec(
+  file: string,
+  args: readonly string[] = [],
+): Promise<void> {
+  debug('running command=%s args=%o', file, args);
+  const process = spawn(file, args);
+  const pid = process.pid;
+  debug('process %d spawned (command=%s args=%o)', pid, file, args);
+
+  return new Promise((resolve, reject) => {
+    process.on('error', (error) => {
+      reject(error);
+    });
+
+    process.on('close', (code, signal) => {
+      debug(
+        'process %d exited with code=%d, signal=%s (command=%s args=%o)',
+        pid,
+        code,
+        signal,
+        file,
+        args,
+      );
+
+      if (code !== 0) {
+        reject(
+          makeExecError({
+            code: code ?? undefined,
+            signal,
+            cmd: `${file} ${args.join(' ')}`,
+          }),
+        );
+      }
+
+      resolve();
+    });
+  });
+}

--- a/src/utils/execSync.test.ts
+++ b/src/utils/execSync.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync, SpawnSyncReturns } from 'child_process';
-import exec from './exec';
+import execSync from './execSync';
 import mockOf from '../../test/mockOf';
 
 jest.mock('child_process');
@@ -20,28 +20,28 @@ function mockSpawnSync(results: Partial<SpawnSyncReturns<string>> = {}): void {
 
 test('command with no args', () => {
   mockSpawnSync();
-  const execResults = exec('ls');
+  const execResults = execSync('ls');
   expect(execResults).toEqual({ stdout: '', stderr: '' });
   expect(spawnSync).toHaveBeenCalledWith('ls', [], { input: undefined });
 });
 
 test('command with args', () => {
   mockSpawnSync();
-  const execResults = exec('ls', ['-la']);
+  const execResults = execSync('ls', ['-la']);
   expect(execResults).toEqual({ stdout: '', stderr: '' });
   expect(spawnSync).toHaveBeenCalledWith('ls', ['-la'], { input: undefined });
 });
 
 test('command printing stdout', () => {
   mockSpawnSync({ stdout: 'README.md\n' });
-  const execResults = exec('ls', ['-la']);
+  const execResults = execSync('ls', ['-la']);
   expect(execResults).toEqual({ stdout: 'README.md\n', stderr: '' });
   expect(spawnSync).toHaveBeenCalledWith('ls', ['-la'], { input: undefined });
 });
 
 test('failed command printing stderr', () => {
   mockSpawnSync({ status: 1, stderr: 'unknown option "-x"' });
-  expect(() => exec('ls', ['-x'])).toThrowError(
+  expect(() => execSync('ls', ['-x'])).toThrowError(
     expect.objectContaining({
       stderr: 'unknown option "-x"',
       code: 1,
@@ -52,7 +52,7 @@ test('failed command printing stderr', () => {
 
 test('command with stdin', () => {
   mockSpawnSync();
-  exec('lpr', ['-P', 'VxPrinter'], 'foobarbaz to print');
+  execSync('lpr', ['-P', 'VxPrinter'], 'foobarbaz to print');
   expect(spawnSync).toHaveBeenCalledWith('lpr', ['-P', 'VxPrinter'], {
     input: 'foobarbaz to print',
   });
@@ -60,7 +60,7 @@ test('command with stdin', () => {
 
 test('unknown command', () => {
   mockSpawnSync({ error: new Error('Error: spawnSync not-a-command ENOENT') });
-  expect(() => exec('not-a-command')).toThrowError(
+  expect(() => execSync('not-a-command')).toThrowError(
     'Error: spawnSync not-a-command ENOENT',
   );
 });

--- a/src/utils/execSync.ts
+++ b/src/utils/execSync.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'child_process';
+import { ExecResult, makeExecError } from './execTypes';
 import makeDebug from 'debug';
 
-const debug = makeDebug('kiosk-browser:exec');
+const debug = makeDebug('kiosk-browser:exec:sync');
 
 /**
  * The native `child_process.execSync` function does not do input sanitization
@@ -12,7 +13,7 @@ export default function execSync(
   file: string,
   args: readonly string[] = [],
   input?: string | Buffer,
-): { stdout: string; stderr: string } {
+): ExecResult {
   debug('running command=%s args=%o stdin=%s', file, args, typeof input);
   const {
     stdout: stdoutBuffer,
@@ -46,54 +47,4 @@ export default function execSync(
     });
   }
   return { stdout, stderr };
-}
-
-export interface ExecError {
-  code: number;
-  killed: boolean;
-  signal: string | null;
-  stdout: string;
-  stderr: string;
-  cmd: string;
-}
-
-export function makeExecError({
-  code = 1,
-  signal = null,
-  killed = false,
-  stdout = '',
-  stderr = '',
-  cmd = '',
-}: Partial<ExecError> = {}): ExecError & Error {
-  const error = new Error(
-    `Error: Command failed: ${cmd} (stdout=${stdout} stderr=${stderr})`,
-  ) as unknown as ExecError & Error;
-
-  Object.defineProperties(error, {
-    killed: {
-      value: killed,
-    },
-
-    code: {
-      value: code,
-    },
-
-    signal: {
-      value: signal,
-    },
-
-    cmd: {
-      value: cmd,
-    },
-
-    stdout: {
-      value: stdout,
-    },
-
-    stderr: {
-      value: stderr,
-    },
-  });
-
-  return error;
 }

--- a/src/utils/execSync.ts
+++ b/src/utils/execSync.ts
@@ -4,9 +4,11 @@ import makeDebug from 'debug';
 const debug = makeDebug('kiosk-browser:exec');
 
 /**
- * Like `child_process.exec`, but with easy stdin.
+ * The native `child_process.execSync` function does not do input sanitization
+ * so is vulnerable to injection attacks. This implementation uses
+ * `child_process.spawnSync` under the hood, which does sanitize input.
  */
-export default function exec(
+export default function execSync(
   file: string,
   args: readonly string[] = [],
   input?: string | Buffer,

--- a/src/utils/execTypes.ts
+++ b/src/utils/execTypes.ts
@@ -1,0 +1,54 @@
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface ExecError {
+  code: number;
+  killed: boolean;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+  cmd: string;
+}
+
+export function makeExecError({
+  code = 1,
+  signal = null,
+  killed = false,
+  stdout = '',
+  stderr = '',
+  cmd = '',
+}: Partial<ExecError> = {}): ExecError & Error {
+  const error = new Error(
+    `Error: Command failed: ${cmd} (stdout=${stdout} stderr=${stderr})`,
+  ) as unknown as ExecError & Error;
+
+  Object.defineProperties(error, {
+    killed: {
+      value: killed,
+    },
+
+    code: {
+      value: code,
+    },
+
+    signal: {
+      value: signal,
+    },
+
+    cmd: {
+      value: cmd,
+    },
+
+    stdout: {
+      value: stdout,
+    },
+
+    stderr: {
+      value: stderr,
+    },
+  });
+
+  return error;
+}

--- a/src/utils/printing/configurePrinter.test.ts
+++ b/src/utils/printing/configurePrinter.test.ts
@@ -1,8 +1,8 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import configurePrinter from './configurePrinter';
 import { PostScriptPrinterDefinition } from '.';
 
-jest.mock('../exec');
+jest.mock('../execSync');
 
 test('configure with PPD file', () => {
   const printerName = 'Example_Printer';
@@ -11,8 +11,8 @@ test('configure with PPD file', () => {
 
   configurePrinter({ printerName, deviceURI, ppd });
 
-  expect(exec).toHaveBeenCalledTimes(1);
-  expect(exec).toHaveBeenCalledWith('lpadmin', [
+  expect(execSync).toHaveBeenCalledTimes(1);
+  expect(execSync).toHaveBeenCalledWith('lpadmin', [
     '-p',
     printerName,
     '-v',
@@ -32,8 +32,8 @@ test('configure with PPD model', () => {
 
   configurePrinter({ printerName, deviceURI, ppd });
 
-  expect(exec).toHaveBeenCalledTimes(1);
-  expect(exec).toHaveBeenCalledWith('lpadmin', [
+  expect(execSync).toHaveBeenCalledTimes(1);
+  expect(execSync).toHaveBeenCalledWith('lpadmin', [
     '-p',
     printerName,
     '-v',
@@ -51,6 +51,6 @@ test('configure as default', () => {
 
   configurePrinter({ printerName, deviceURI, ppd, setDefault: true });
 
-  expect(exec).toHaveBeenCalledTimes(2);
-  expect(exec).toHaveBeenNthCalledWith(2, 'lpadmin', ['-d', printerName]);
+  expect(execSync).toHaveBeenCalledTimes(2);
+  expect(execSync).toHaveBeenNthCalledWith(2, 'lpadmin', ['-d', printerName]);
 });

--- a/src/utils/printing/configurePrinter.ts
+++ b/src/utils/printing/configurePrinter.ts
@@ -1,5 +1,5 @@
 import { debug, PostScriptPrinterDefinition } from '.';
-import exec from '../exec';
+import execSync from '../execSync';
 
 /**
  * Configures a printer at a given device URI with a name and PPD. Optionally
@@ -25,7 +25,7 @@ export default function configurePrinter({
   }
 
   debug('configuring printer with lpadmin: args=%o', lpadminConfigureArgs);
-  exec('lpadmin', lpadminConfigureArgs);
+  execSync('lpadmin', lpadminConfigureArgs);
 
   if (setDefault) {
     const lpadminSetDefaultArgs = ['-d', printerName];
@@ -33,6 +33,6 @@ export default function configurePrinter({
       'setting printer as default with lpadmin: args=%o',
       lpadminSetDefaultArgs,
     );
-    exec('lpadmin', lpadminSetDefaultArgs);
+    execSync('lpadmin', lpadminSetDefaultArgs);
   }
 }

--- a/src/utils/printing/getConnectedDeviceURIs.test.ts
+++ b/src/utils/printing/getConnectedDeviceURIs.test.ts
@@ -1,14 +1,14 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import mockOf from '../../../test/mockOf';
 import getConnectedDeviceURIs from './getConnectedDeviceURIs';
 
-jest.mock('../exec', () => jest.fn());
+jest.mock('../execSync', () => jest.fn());
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
 describe('getConnectedDeviceURIs', () => {
   it('calls out to lpinfo without any schemes', () => {
-    execMock.mockReturnValue({
+    execSyncMock.mockReturnValue({
       stdout: 'direct usb://HP/Color%20LaserJet?serial=1234',
       stderr: '',
     });
@@ -17,11 +17,11 @@ describe('getConnectedDeviceURIs', () => {
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
 
-    expect(execMock).toHaveBeenCalledWith('lpinfo', ['-v']);
+    expect(execSyncMock).toHaveBeenCalledWith('lpinfo', ['-v']);
   });
 
   it('calls out to lpinfo with schemes', () => {
-    execMock.mockReturnValue({
+    execSyncMock.mockReturnValue({
       stdout: 'direct usb://HP/Color%20LaserJet?serial=1234',
       stderr: '',
     });
@@ -30,7 +30,7 @@ describe('getConnectedDeviceURIs', () => {
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
 
-    expect(execMock).toHaveBeenCalledWith('lpinfo', [
+    expect(execSyncMock).toHaveBeenCalledWith('lpinfo', [
       '--include-schemes',
       'usb,ippusb',
       '-v',

--- a/src/utils/printing/getConnectedDeviceURIs.ts
+++ b/src/utils/printing/getConnectedDeviceURIs.ts
@@ -1,4 +1,4 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import { debug } from '.';
 
 /**
@@ -20,7 +20,7 @@ export default function getConnectedDeviceURIs(
   lpinfoArgs.push('-v');
 
   debug('getting connected device URIs from lpinfo, args=%o', lpinfoArgs);
-  const { stdout, stderr } = exec('lpinfo', lpinfoArgs);
+  const { stdout, stderr } = execSync('lpinfo', lpinfoArgs);
   debug('lpinfo stdout:\n%s', stdout);
   debug('lpinfo stderr:\n%s', stderr);
 

--- a/src/utils/printing/getPrinterDeviceURI.test.ts
+++ b/src/utils/printing/getPrinterDeviceURI.test.ts
@@ -1,4 +1,5 @@
-import execSync, { makeExecError } from '../execSync';
+import execSync from '../execSync';
+import { makeExecError } from '../execTypes';
 import mockOf from '../../../test/mockOf';
 import getPrinterDeviceURI from './getPrinterDeviceURI';
 

--- a/src/utils/printing/getPrinterDeviceURI.test.ts
+++ b/src/utils/printing/getPrinterDeviceURI.test.ts
@@ -1,13 +1,13 @@
-import exec, { makeExecError } from '../exec';
+import execSync, { makeExecError } from '../execSync';
 import mockOf from '../../../test/mockOf';
 import getPrinterDeviceURI from './getPrinterDeviceURI';
 
-jest.mock('../exec');
+jest.mock('../execSync');
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
 test('missing printer', () => {
-  execMock.mockImplementationOnce(() => {
+  execSyncMock.mockImplementationOnce(() => {
     throw makeExecError({
       cmd: 'lpstat -v missing-printer',
       stderr: 'lpstat: Invalid destination name in list "missing-printer".',
@@ -15,21 +15,24 @@ test('missing printer', () => {
   });
 
   expect(getPrinterDeviceURI('missing-printer')).toBeUndefined();
-  expect(execMock).toHaveBeenCalledWith('lpstat', ['-v', 'missing-printer']);
+  expect(execSyncMock).toHaveBeenCalledWith('lpstat', [
+    '-v',
+    'missing-printer',
+  ]);
 });
 
 test('printer configured with valid destination', () => {
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: 'device for valid-printer: usb://HP/Something\n',
     stderr: '',
   });
 
   expect(getPrinterDeviceURI('valid-printer')).toEqual('usb://HP/Something');
-  expect(execMock).toHaveBeenCalledWith('lpstat', ['-v', 'valid-printer']);
+  expect(execSyncMock).toHaveBeenCalledWith('lpstat', ['-v', 'valid-printer']);
 });
 
 test('different printer returned from `lpstat`', () => {
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: 'device for another-printer: usb://HP/Something\n',
     stderr: '',
   });
@@ -37,11 +40,11 @@ test('different printer returned from `lpstat`', () => {
   expect(() => getPrinterDeviceURI('a-printer')).toThrowError(
     'lpstat returned a different printer than requested: another-printer != a-printer',
   );
-  expect(execMock).toHaveBeenCalledWith('lpstat', ['-v', 'a-printer']);
+  expect(execSyncMock).toHaveBeenCalledWith('lpstat', ['-v', 'a-printer']);
 });
 
 test('`lpstat` gibberish', () => {
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: 'abba gazabba',
     stderr: '',
   });

--- a/src/utils/printing/getPrinterDeviceURI.ts
+++ b/src/utils/printing/getPrinterDeviceURI.ts
@@ -1,4 +1,4 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import { debug } from '.';
 import { ok } from '../assert';
 
@@ -14,7 +14,7 @@ export default function getPrinterDeviceURI(
   let stderr: string;
 
   try {
-    ({ stdout, stderr } = exec('lpstat', ['-v', printerName]));
+    ({ stdout, stderr } = execSync('lpstat', ['-v', printerName]));
   } catch (error) {
     debug('`lpstat` failed with error: %O', error);
     return undefined;

--- a/src/utils/printing/getPrinterIppAttributes.test.ts
+++ b/src/utils/printing/getPrinterIppAttributes.test.ts
@@ -1,15 +1,15 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import mockOf from '../../../test/mockOf';
 import { fakeIpptoolStdout, fakeMarkerInfo } from '../../../test/fakePrinter';
 import { getPrinterIppAttributes } from './getPrinterIppAttributes';
 
-jest.mock('../exec');
+jest.mock('../execSync');
 
 const ippUri = 'ipp://localhost:60000/ipp/print';
 
 describe('getPrinterIppAttributes', () => {
   it('uses ipptool to query and parse printer atttributes', () => {
-    mockOf(exec).mockReturnValueOnce({
+    mockOf(execSync).mockReturnValueOnce({
       stdout: fakeIpptoolStdout(),
       stderr: '',
     });
@@ -21,7 +21,7 @@ describe('getPrinterIppAttributes', () => {
   });
 
   it('parses multiple marker infos', () => {
-    mockOf(exec).mockReturnValueOnce({
+    mockOf(execSync).mockReturnValueOnce({
       stdout: fakeIpptoolStdout({
         'marker-names':
           '(1setOf nameWithoutLanguage) = black cartridge,color cartridge',
@@ -51,7 +51,7 @@ describe('getPrinterIppAttributes', () => {
   });
 
   it('parses multiple printer-state-reasons', () => {
-    mockOf(exec).mockReturnValueOnce({
+    mockOf(execSync).mockReturnValueOnce({
       stdout: fakeIpptoolStdout({
         'printer-state': '(enum) = stopped',
         'printer-state-reasons':
@@ -71,7 +71,7 @@ describe('getPrinterIppAttributes', () => {
   });
 
   it('creates a special printer-state-reason if HP sleep mode detected', () => {
-    mockOf(exec).mockReturnValueOnce({
+    mockOf(execSync).mockReturnValueOnce({
       stdout: fakeIpptoolStdout({
         'printer-alert-description':
           '(1setOf textWithoutLanguage) = ,Ready,Sleep Mode',
@@ -86,7 +86,7 @@ describe('getPrinterIppAttributes', () => {
   });
 
   it('throws an error if ipptool fails', () => {
-    mockOf(exec).mockImplementationOnce(() => {
+    mockOf(execSync).mockImplementationOnce(() => {
       throw new Error('ipptool failed');
     });
     expect(() => getPrinterIppAttributes(ippUri)).toThrow(
@@ -156,7 +156,7 @@ describe('getPrinterIppAttributes', () => {
       ],
     ];
     for (const [stdout, expectedError] of badOutput) {
-      mockOf(exec).mockReturnValueOnce({ stdout, stderr: '' });
+      mockOf(execSync).mockReturnValueOnce({ stdout, stderr: '' });
       expect(() => getPrinterIppAttributes(ippUri)).toThrow(
         new Error(expectedError),
       );

--- a/src/utils/printing/getPrinterIppAttributes.ts
+++ b/src/utils/printing/getPrinterIppAttributes.ts
@@ -1,4 +1,4 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import { debug } from '.';
 import assert from 'assert';
 import tmp from 'tmp';
@@ -88,7 +88,7 @@ export function getPrinterIppAttributes(
   debug('getting printer IPP attributes from ipptool, args=%o', ipptoolArgs);
   let ipptoolResult: { stdout: string; stderr: string };
   try {
-    ipptoolResult = exec(`ipptool`, ipptoolArgs);
+    ipptoolResult = execSync(`ipptool`, ipptoolArgs);
     debug('ipptool stdout:\n%s', ipptoolResult.stdout);
     debug('ipptool stderr:\n%s', ipptoolResult.stderr);
 

--- a/src/utils/printing/options.test.ts
+++ b/src/utils/printing/options.test.ts
@@ -1,13 +1,13 @@
 import { parsePrinterOptions, getPrinterOptions } from './options';
-import exec from '../exec';
+import execSync from '../execSync';
 import mockOf from '../../../test/mockOf';
 
-jest.mock('../exec');
+jest.mock('../execSync');
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
 beforeEach(() => {
-  execMock.mockRestore();
+  execSyncMock.mockRestore();
 });
 
 test('parse empty options', () => {
@@ -251,7 +251,7 @@ HPFTDigit/Fourth Digit: *0 1 2 3 4 5 6 7 8 9
 });
 
 test('options for default printer', () => {
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: 'Opt/Option Name: A B',
     stderr: '',
   });
@@ -264,11 +264,11 @@ test('options for default printer', () => {
     },
   });
 
-  expect(exec).toHaveBeenCalledWith('lpoptions', ['-l']);
+  expect(execSync).toHaveBeenCalledWith('lpoptions', ['-l']);
 });
 
 test('options for named printer', () => {
-  execMock.mockReturnValueOnce({
+  execSyncMock.mockReturnValueOnce({
     stdout: 'Opt/Option Name: A B',
     stderr: '',
   });
@@ -281,5 +281,5 @@ test('options for named printer', () => {
     },
   });
 
-  expect(exec).toHaveBeenCalledWith('lpoptions', ['-p', 'VxPrinter', '-l']);
+  expect(execSync).toHaveBeenCalledWith('lpoptions', ['-p', 'VxPrinter', '-l']);
 });

--- a/src/utils/printing/options.ts
+++ b/src/utils/printing/options.ts
@@ -1,4 +1,4 @@
-import exec from '../exec';
+import execSync from '../execSync';
 import { debug } from '.';
 
 export interface PrinterOption {
@@ -63,7 +63,7 @@ export function getPrinterOptions(deviceName?: string): PrinterOptionMap {
   lpoptionsArgs.push('-l'); // -l == list
 
   debug('calling lpoptions with args=%o', lpoptionsArgs);
-  const { stdout, stderr } = exec('lpoptions', lpoptionsArgs);
+  const { stdout, stderr } = execSync('lpoptions', lpoptionsArgs);
   debug('lpoptions returned stdout=%s, stderr=%s', stdout, stderr);
 
   const options = parsePrinterOptions(stdout);

--- a/src/utils/promisifiedExec.ts
+++ b/src/utils/promisifiedExec.ts
@@ -1,5 +1,0 @@
-import { promisify } from 'util';
-import { exec } from 'child_process';
-
-const promisifiedExec = promisify(exec);
-export default promisifiedExec;

--- a/src/utils/screen.test.ts
+++ b/src/utils/screen.test.ts
@@ -1,13 +1,13 @@
-import exec from './exec';
+import execSync from './execSync';
 import mockOf from '../../test/mockOf';
 import { getMainScreen } from './screen';
 
-jest.mock('./exec', () => jest.fn());
+jest.mock('./execSync', () => jest.fn());
 
-const execMock = mockOf(exec);
+const execSyncMock = mockOf(execSync);
 
 test('`getMainScreen` gets screen information for the first connected screen', () => {
-  execMock.mockReturnValue({
+  execSyncMock.mockReturnValue({
     stdout: `Screen 0: minimum 0 x 0, current 1314 x 760, maximum 8196 x 8196
 Virtual1 disconnected
 Virtual2 connected primary 1314x760+0+0 0mm x 0mm
@@ -55,7 +55,7 @@ Virtual6 disconnected`,
 });
 
 test('`getMainScreen` returns nothing if there are no connected screens', () => {
-  execMock.mockReturnValue({
+  execSyncMock.mockReturnValue({
     stdout: '',
     stderr: '',
   });

--- a/src/utils/screen.ts
+++ b/src/utils/screen.ts
@@ -1,11 +1,11 @@
-import exec from './exec';
+import execSync from './execSync';
 import xrandrParse, { Screen } from 'xrandr-parse';
 
 /**
  * Gets information about the main screen.
  */
 export function getMainScreen(): Screen | undefined {
-  const { stdout } = exec('xrandr', ['--query']);
+  const { stdout } = execSync('xrandr', ['--query']);
   const screens = xrandrParse(
     stdout.replace(/connected primary/g, 'connected'),
   ); // xrandr-parse doesn't understand "primary"


### PR DESCRIPTION
- Renames the synchronous `exec` util to `execSync` to remain consistent with node defaults
- Creates new asynchronous `exec` function, which replaces the problematic `promisifiedExec`

Chose to limit scope a bit to not provide `stdout` and `stderr` for the new `exec` because we don't need it. It's easy to implement but difficult to test.

All tests passing with `IS_CI=true yarn test:ci`. Manually tested that `syncUsbDrive` still works as expected.