### PR TITLE
make exec async again

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "luxon": "^1.25.0",
     "multimatch": "^4.0.0",
     "rxjs": "^6.5.4",
-    "tmp": "^0.2.1",
+    "tmp-promise": "^3.0.3",
     "usb-detection": "^4.14.1",
     "uuid": "^8.3.1",
     "xrandr-parse": "^1.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ async function createWindow(): Promise<void> {
   const autoconfigurePrinterSubscription =
     autoconfigurePrinterObservable?.subscribe();
 
-  const mainScreen = getMainScreen();
+  const mainScreen = await getMainScreen();
 
   // Create the browser window.
   mainWindow = new BrowserWindow({

--- a/src/ipc/clock.test.ts
+++ b/src/ipc/clock.test.ts
@@ -8,7 +8,7 @@ jest.mock('../utils/exec');
 
 beforeEach(() => {
   execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
 const { ipcMain, ipcRenderer } = fakeIpc();
@@ -57,11 +57,9 @@ test('set datetime works in non- daylights savings', async () => {
 });
 
 test('set datetime fails when NTP is enabled', async () => {
-  execMock.mockImplementationOnce(() => {
-    throw new Error(
-      'Failed to set time: Automatic time synchronization is enabled',
-    );
-  });
+  execMock.mockRejectedValueOnce(
+    new Error('Failed to set time: Automatic time synchronization is enabled'),
+  );
 
   await expect(
     ipcRenderer.invoke(setClockChannel, {

--- a/src/ipc/clock.ts
+++ b/src/ipc/clock.ts
@@ -4,23 +4,23 @@ import exec from '../utils/exec';
 
 export const channel = 'setClock';
 
-function clockSet({
+async function clockSet({
   isoDatetime,
   IANAZone,
-}: KioskBrowser.SetClockParams): void {
+}: KioskBrowser.SetClockParams): Promise<void> {
   const datetimeString = DateTime.fromISO(isoDatetime, {
     zone: IANAZone,
   }).toFormat('yyyy-LL-dd TT');
-  exec('sudo', ['-n', 'timedatectl', 'set-timezone', IANAZone]);
-  exec('sudo', ['-n', 'timedatectl', 'set-time', datetimeString]);
+  await exec('sudo', ['-n', 'timedatectl', 'set-timezone', IANAZone]);
+  await exec('sudo', ['-n', 'timedatectl', 'set-time', datetimeString]);
 }
 
 export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(
     channel,
-    (event: IpcMainInvokeEvent, params: KioskBrowser.SetClockParams) => {
+    async (event: IpcMainInvokeEvent, params: KioskBrowser.SetClockParams) => {
       try {
-        clockSet(params);
+        await clockSet(params);
       } catch (err) {
         const error = err as Error;
         if ('stderr' in error) {

--- a/src/ipc/get-printer-info.test.ts
+++ b/src/ipc/get-printer-info.test.ts
@@ -18,13 +18,13 @@ jest.mock('../utils/printing/getConnectedDeviceURIs');
 jest.mock('../utils/exec');
 
 describe('getPrinterInfo', () => {
-  it('expands the printer info with connected=true if lpinfo shows the device', () => {
-    mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+  it('expands the printer info with connected=true if lpinfo shows the device', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
 
     expect(
-      getPrinterInfo([
+      await getPrinterInfo([
         fakeElectronPrinter(),
         fakeElectronPrinter({
           options: { 'device-uri': 'usb://HP/Color%20LaserJet?serial=1234' },
@@ -36,11 +36,11 @@ describe('getPrinterInfo', () => {
     ]);
   });
 
-  it('expands the printer info with connected=false if lpinfo does not show the device', () => {
-    mockOf(getConnectedDeviceURIs).mockReturnValue(new Set());
+  it('expands the printer info with connected=false if lpinfo does not show the device', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValue(new Set());
 
     expect(
-      getPrinterInfo([
+      await getPrinterInfo([
         fakeElectronPrinter({
           options: { 'device-uri': 'usb://HP/Color%20LaserJet?serial=1234' },
         }),
@@ -48,14 +48,14 @@ describe('getPrinterInfo', () => {
     ).toEqual([expect.objectContaining({ connected: false })]);
   });
 
-  it('expands the printer info with connected=true if lpinfo shows the device after a momentary blip', () => {
-    mockOf(getConnectedDeviceURIs).mockReturnValueOnce(new Set());
-    mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+  it('expands the printer info with connected=true if lpinfo shows the device after a momentary blip', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(new Set());
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
 
     expect(
-      getPrinterInfo([
+      await getPrinterInfo([
         fakeElectronPrinter(),
         fakeElectronPrinter({
           options: { 'device-uri': 'usb://HP/Color%20LaserJet?serial=1234' },
@@ -67,17 +67,17 @@ describe('getPrinterInfo', () => {
     ]);
   });
 
-  it('adds IPP attributes for connected printers', () => {
-    mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+  it('adds IPP attributes for connected printers', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
-    mockOf(exec).mockReturnValue({
+    mockOf(exec).mockResolvedValue({
       stdout: fakeIpptoolStdout(),
       stderr: '',
     });
 
     expect(
-      getPrinterInfo([
+      await getPrinterInfo([
         fakeElectronPrinter(),
         fakeElectronPrinter({
           name: 'other printer',
@@ -104,16 +104,14 @@ describe('getPrinterInfo', () => {
     ]);
   });
 
-  it('adds empty IPP attributes if ipptool fails', () => {
-    mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+  it('adds empty IPP attributes if ipptool fails', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
-    mockOf(exec).mockImplementation(() => {
-      throw new Error('ipptool failed');
-    });
+    mockOf(exec).mockRejectedValue(new Error('ipptool failed'));
 
     expect(
-      getPrinterInfo([
+      await getPrinterInfo([
         fakeElectronPrinter({
           options: { 'device-uri': 'usb://HP/Color%20LaserJet?serial=1234' },
         }),
@@ -129,18 +127,16 @@ describe('getPrinterInfo', () => {
     ]);
   });
 
-  it('retries if ipptool fails', () => {
-    mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+  it('retries if ipptool fails', async () => {
+    mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
     mockOf(exec)
-      .mockImplementationOnce(() => {
-        throw new Error('ipptool failed');
-      })
-      .mockReturnValueOnce({ stdout: fakeIpptoolStdout(), stderr: '' });
+      .mockRejectedValueOnce(new Error('ipptool failed'))
+      .mockResolvedValueOnce({ stdout: fakeIpptoolStdout(), stderr: '' });
 
     expect(
-      getPrinterInfo([
+      await getPrinterInfo([
         fakeElectronPrinter({
           options: { 'device-uri': 'usb://HP/Color%20LaserJet?serial=1234' },
         }),
@@ -170,7 +166,7 @@ test('registers an IPC handler for getting printer info', async () => {
 
   register(ipcMain);
 
-  mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+  mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
     new Set(['usb://HP/Color%20LaserJet?serial=1234']),
   );
 

--- a/src/ipc/get-printer-info.ts
+++ b/src/ipc/get-printer-info.ts
@@ -26,12 +26,12 @@ export type PrinterInfo = Omit<Electron.PrinterInfo, 'status'> &
 /**
  * Get information about all known printers, including connection status.
  */
-export function getPrinterInfo(
+export async function getPrinterInfo(
   printers: Electron.PrinterInfo[],
-): PrinterInfo[] {
-  const printersWithConnectionStatus = retryUntil(
-    () => {
-      const connectedDeviceURIs = getConnectedDeviceURIs(
+): Promise<PrinterInfo[]> {
+  const printersWithConnectionStatus = await retryUntil(
+    async () => {
+      const connectedDeviceURIs = await getConnectedDeviceURIs(
         printerSchemes(printers),
       );
       return printers.map((printer) => {
@@ -56,7 +56,7 @@ export function getPrinterInfo(
     // one printer is connected and use this URI to query its IPP attributes.
     // https://wiki.debian.org/CUPSDriverlessPrinting#IPP-over-USB:_Investigation_and_Troubleshooting
     try {
-      ippAttributes = retry(
+      ippAttributes = await retry(
         () => getPrinterIppAttributes('ipp://localhost:60000/ipp/print'),
         { tries: IPP_ATTRIBUTES_NUM_TRIES },
       );

--- a/src/ipc/get-usb-drives.test.ts
+++ b/src/ipc/get-usb-drives.test.ts
@@ -36,7 +36,7 @@ test('get-usb-drives', async () => {
   ]);
   readlinkMock.mockResolvedValueOnce('../../sdb1');
   readlinkMock.mockResolvedValueOnce('../../sdc1');
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: JSON.stringify({
       blockdevices: [
         {
@@ -52,7 +52,7 @@ test('get-usb-drives', async () => {
     }),
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: JSON.stringify({
       blockdevices: [
         {
@@ -69,7 +69,7 @@ test('get-usb-drives', async () => {
     stderr: '',
   });
 
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: JSON.stringify({
       filesystems: [
         {
@@ -118,7 +118,7 @@ test('get-usb-drives works when findmnt returns nothing', async () => {
 
   readdirMock.mockResolvedValueOnce(['usb-foobar-part23']);
   readlinkMock.mockResolvedValueOnce('../../sdb1');
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: JSON.stringify({
       blockdevices: [
         {
@@ -135,7 +135,7 @@ test('get-usb-drives works when findmnt returns nothing', async () => {
     stderr: '',
   });
 
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });

--- a/src/ipc/mount-usb-drive.test.ts
+++ b/src/ipc/mount-usb-drive.test.ts
@@ -13,7 +13,7 @@ test('mount-usb-drive', async () => {
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -36,7 +36,7 @@ test('mount-usb-drive with custom label', async () => {
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });

--- a/src/ipc/mount-usb-drive.ts
+++ b/src/ipc/mount-usb-drive.ts
@@ -9,8 +9,8 @@ export interface Options {
   label?: string;
 }
 
-function mountUsbDrive(options: Options): void {
-  exec('pmount', [
+async function mountUsbDrive(options: Options): Promise<void> {
+  await exec('pmount', [
     '-w',
     '-u',
     '000',
@@ -20,7 +20,10 @@ function mountUsbDrive(options: Options): void {
 }
 
 export default function register(ipcMain: IpcMain): void {
-  ipcMain.handle(channel, (event: IpcMainInvokeEvent, options: Options) => {
-    mountUsbDrive(options);
-  });
+  ipcMain.handle(
+    channel,
+    async (event: IpcMainInvokeEvent, options: Options) => {
+      await mountUsbDrive(options);
+    },
+  );
 }

--- a/src/ipc/prepare-boot-usb.test.ts
+++ b/src/ipc/prepare-boot-usb.test.ts
@@ -17,7 +17,7 @@ test('prepare-boot-usb returns false when no bootable usbs', async () => {
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: `BootCurrent: 0005
 Timeout: 0 seconds
 BootOrder: 0005,0002,0001,0003,0000,0004
@@ -45,7 +45,7 @@ test('prepare-boot-usb returns true when expected and sets correct boot order', 
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
@@ -57,7 +57,7 @@ Boot2003* EFI Network	RC
        `,
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -81,7 +81,7 @@ test('prepare-boot-usb returns true with a USB HDD entry that has a GPT partitio
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
@@ -92,7 +92,7 @@ Boot2003* EFI Network	RC
        `,
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });
@@ -116,7 +116,7 @@ test('prepare-boot-usb returns true when there is a fallback Boot Menu option', 
   register(ipcMain);
 
   // Things should be registered as expected.
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: `BootCurrent: 0000
 Timeout: 0 seconds
 BootOrder: 0000
@@ -128,7 +128,7 @@ Boot200E  Boot Menu	RC
        `,
     stderr: '',
   });
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });

--- a/src/ipc/prepare-boot-usb.ts
+++ b/src/ipc/prepare-boot-usb.ts
@@ -50,8 +50,8 @@ function parseEfiBootMgrOutput(output: string): BootOption[] {
  * Attempts to update set the boot manager to boot from a usb device. Returns true
  * if successful, returns false if there are either 0 or more then 1 bootable usb drives available.
  */
-function prepareToBootFromUsb(): boolean {
-  const { stdout: bootStdout } = exec('efibootmgr', ['-v']);
+async function prepareToBootFromUsb(): Promise<boolean> {
+  const { stdout: bootStdout } = await exec('efibootmgr', ['-v']);
   const bootOptions = parseEfiBootMgrOutput(bootStdout);
   const linpusBootOption = bootOptions.find((bootOption) =>
     bootOption.restOfEntry.includes('Linpus'),
@@ -71,7 +71,7 @@ function prepareToBootFromUsb(): boolean {
   debug(
     'The USB boot option was properly located setting it to be next in the boot order…',
   );
-  exec('sudo', ['-n', '/bin/efibootmgr', '-n', nextBoot.bootNumber]);
+  await exec('sudo', ['-n', '/bin/efibootmgr', '-n', nextBoot.bootNumber]);
   return true;
 }
 
@@ -79,5 +79,7 @@ function prepareToBootFromUsb(): boolean {
  * Registers a handler to set the boot order to boot from the given usb device next.
  */
 export default function register(ipcMain: IpcMain): void {
-  ipcMain.handle(channel, () => prepareToBootFromUsb());
+  ipcMain.handle(channel, async () => {
+    return await prepareToBootFromUsb();
+  });
 }

--- a/src/ipc/print.test.ts
+++ b/src/ipc/print.test.ts
@@ -26,7 +26,7 @@ test('registers a handler to trigger a print', async () => {
 
   register(ipcMain);
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, {
     deviceName: 'mainprinter',
@@ -57,7 +57,7 @@ test('uses the preferred printer if none is provided', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel);
 
@@ -98,7 +98,7 @@ test('prints a specified number of copies', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, { copies: 123 });
 
@@ -124,7 +124,7 @@ test('does not allow fractional copies', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
   await expect(
     ipcRenderer.invoke(printChannel, { copies: 1.23 }),
@@ -147,7 +147,7 @@ test('allows specifying one-sided duplex', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, { sides: PrintSides.OneSided });
 
@@ -171,7 +171,7 @@ test('allows specifying two-sided-short-edge duplex', async () => {
     fakeElectronPrinter({ name: 'main printer' }),
   );
 
-  execMock.mockReturnValueOnce({ stdout: '', stderr: '' });
+  execMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
   await ipcRenderer.invoke(printChannel, {
     sides: PrintSides.TwoSidedShortEdge,

--- a/src/ipc/print.ts
+++ b/src/ipc/print.ts
@@ -59,13 +59,13 @@ interface PrintDataParameters extends PrintOptions {
   data: Buffer;
 }
 
-function printData({
+async function printData({
   data,
   deviceName,
   paperSource,
   copies,
   sides = PrintSides.TwoSidedLongEdge,
-}: PrintDataParameters): void {
+}: PrintDataParameters): Promise<void> {
   const lprOptions: string[] = [];
 
   if (deviceName) {
@@ -86,7 +86,7 @@ function printData({
 
   debug('printing via lpr with args=%o', lprOptions);
   debug('data length is %d', data.length);
-  const { stdout, stderr } = exec('lpr', lprOptions, data);
+  const { stdout, stderr } = await exec('lpr', lprOptions, data);
   debug('`lpr` succeeded with stdout=%s stderr=%s', stdout, stderr);
 }
 
@@ -106,7 +106,7 @@ export default function register(ipcMain: IpcMain): void {
       });
       debug('printed to PDF, size=%d', data.length);
 
-      printData({
+      await printData({
         data,
         deviceName:
           deviceName ??

--- a/src/ipc/printer-subscription.test.ts
+++ b/src/ipc/printer-subscription.test.ts
@@ -12,7 +12,9 @@ import register, {
 
 jest.mock('./get-printer-info');
 
-const getPrinterInfoMock = mockOf(getPrinterInfo);
+const getPrinterInfoMock = mockOf(getPrinterInfo).mockRejectedValue(
+  new Error('no mocks ready'),
+);
 
 test('printer observer triggers on devices change', async () => {
   const onDevicesChange = new Subject<void>();
@@ -28,7 +30,7 @@ test('printer observer triggers on devices change', async () => {
   expect(callback).not.toHaveBeenCalled();
 
   // Trigger change and wait for promises.
-  getPrinterInfoMock.mockReturnValueOnce([printer]);
+  getPrinterInfoMock.mockResolvedValueOnce([printer]);
   onDevicesChange.next();
 
   // wait for promises to resolve twice, once for each `switchMap/from`
@@ -52,7 +54,7 @@ test('printer observer triggers on printer configure', async () => {
   expect(callback).not.toHaveBeenCalled();
 
   // Trigger change and wait for promises.
-  getPrinterInfoMock.mockReturnValueOnce([printer]);
+  getPrinterInfoMock.mockResolvedValueOnce([printer]);
   onPrinterConfigure.next();
 
   // wait for promises to resolve twice, once for each `switchMap/from`
@@ -76,7 +78,7 @@ test('printer observer triggers multiple times', async () => {
   expect(callback).not.toHaveBeenCalled();
 
   // Trigger change and wait for promises.
-  getPrinterInfoMock.mockReturnValueOnce([printer]);
+  getPrinterInfoMock.mockResolvedValueOnce([printer]);
   onDevicesChange.next();
 
   // wait for promises to resolve twice, once for each `switchMap/from`
@@ -84,7 +86,7 @@ test('printer observer triggers multiple times', async () => {
   await Promise.resolve();
 
   // Trigger change and wait for promises.
-  getPrinterInfoMock.mockReturnValueOnce([printer]);
+  getPrinterInfoMock.mockResolvedValueOnce([printer]);
   onPrinterConfigure.next();
 
   // wait for promises to resolve twice, once for each `switchMap/from`
@@ -114,9 +116,9 @@ test('registering a subscription handler hooks up to both USB devices and autoco
   await ipcRenderer.invoke(printerSubscriptionChannel, { subscribe: true });
 
   expect(webContents.send).not.toHaveBeenCalled();
-  getPrinterInfoMock.mockImplementation(() => {
+  getPrinterInfoMock.mockImplementationOnce(() => {
     resolve();
-    return [printer];
+    return Promise.resolve([printer]);
   });
 
   // Trigger device change and wait.
@@ -152,7 +154,7 @@ test('unsubscribe', async () => {
 
   getPrinterInfoMock.mockImplementationOnce(() => {
     resolve();
-    return [printer];
+    return Promise.resolve([printer]);
   });
 
   // Trigger device change and wait.
@@ -188,7 +190,7 @@ test('unsubscribe on webContents teardown', async () => {
 
   getPrinterInfoMock.mockImplementationOnce(() => {
     resolve();
-    return [printer];
+    return Promise.resolve([printer]);
   });
 
   // Trigger device change and wait.

--- a/src/ipc/printer-subscription.ts
+++ b/src/ipc/printer-subscription.ts
@@ -1,5 +1,5 @@
 import { IpcMainInvokeEvent, WebContents } from 'electron';
-import { from, merge, Observable, of, Subscription } from 'rxjs';
+import { from, merge, Observable, Subscription } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 import { RegisterIpcHandler } from '..';
 import { debug } from '../utils/printing';
@@ -22,7 +22,7 @@ export function buildPrinterObserver(
     ),
   ).pipe(
     switchMap(() => from(getPrinters())),
-    switchMap((printers) => of(getPrinterInfo(printers))),
+    switchMap((printers) => from(getPrinterInfo(printers))),
   );
 }
 

--- a/src/ipc/reboot-to-bios.test.ts
+++ b/src/ipc/reboot-to-bios.test.ts
@@ -8,7 +8,7 @@ jest.mock('../utils/exec');
 
 beforeEach(() => {
   execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
 test('reboot to bios', async () => {

--- a/src/ipc/reboot-to-bios.ts
+++ b/src/ipc/reboot-to-bios.ts
@@ -8,6 +8,6 @@ export const channel = 'reboot-to-bios';
  */
 export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(channel, () => {
-    exec('systemctl', ['reboot', '--firmware-setup']);
+    void exec('systemctl', ['reboot', '--firmware-setup']);
   });
 }

--- a/src/ipc/reboot.test.ts
+++ b/src/ipc/reboot.test.ts
@@ -8,7 +8,7 @@ jest.mock('../utils/exec');
 
 beforeEach(() => {
   execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
 test('reboot', async () => {

--- a/src/ipc/reboot.ts
+++ b/src/ipc/reboot.ts
@@ -8,6 +8,6 @@ export const channel = 'reboot';
  */
 export default function register(ipcMain: IpcMain): void {
   ipcMain.handle(channel, () => {
-    exec('reboot');
+    void exec('reboot');
   });
 }

--- a/src/ipc/sign.test.ts
+++ b/src/ipc/sign.test.ts
@@ -9,7 +9,7 @@ jest.mock('../utils/exec');
 
 beforeEach(() => {
   execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
 const changedDevices = new Subject<Iterable<KioskBrowser.Device>>();
@@ -27,7 +27,7 @@ test('call to sign invokes the right signing script command, but only if signatu
     },
   });
 
-  execMock.mockReturnValue({
+  execMock.mockResolvedValue({
     stderr: '',
     stdout: 'untrusted comment: hello\nFAKESIGNATURERIGHTHERE==\n',
   });
@@ -86,7 +86,7 @@ test('call to sign when error occurs or exception thrown returns undefined', asy
     },
   });
 
-  execMock.mockReturnValue({
+  execMock.mockResolvedValue({
     stderr: 'oopsie daisy',
     stdout:
       'untrusted comment: hello\nFAKESIGNATURERIGHTHERETHATSHOULDNOTBERETURNEDBECAUSESTDERR==\n',
@@ -103,9 +103,7 @@ test('call to sign when error occurs or exception thrown returns undefined', asy
 
   execMock.mockReset();
 
-  execMock.mockImplementationOnce(() => {
-    throw new Error('throwing cause I feel like it');
-  });
+  execMock.mockRejectedValueOnce('throwing cause I feel like it');
 
   const signResultWithThrow = (await ipcRenderer.invoke(signChannel, {
     signatureType: 'test',

--- a/src/ipc/sign.ts
+++ b/src/ipc/sign.ts
@@ -12,10 +12,10 @@ export interface SignParams {
   payload: string;
 }
 
-function sign(
+async function sign(
   { signatureType, payload }: SignParams,
   signingScriptPath?: string,
-): string | undefined {
+): Promise<string | undefined> {
   if (!signingScriptPath) {
     debug('could not sign because no signing script specified!');
     return;
@@ -29,7 +29,7 @@ function sign(
   const rawPayloadToSign = `${signatureType}.${payload}`;
 
   try {
-    const { stdout, stderr } = exec(
+    const { stdout, stderr } = await exec(
       // TODO this feels really dangerous, is there a better way?
       signingScriptPath,
       [],
@@ -50,8 +50,11 @@ function sign(
 }
 
 const register: RegisterIpcHandler = (ipcMain: IpcMain, { options }): void => {
-  ipcMain.handle(channel, (event: IpcMainInvokeEvent, params: SignParams) =>
-    sign(params, options.signingScriptPath),
+  ipcMain.handle(
+    channel,
+    async (event: IpcMainInvokeEvent, params: SignParams) => {
+      return await sign(params, options.signingScriptPath);
+    },
   );
 };
 

--- a/src/ipc/sync-usb-drive.test.ts
+++ b/src/ipc/sync-usb-drive.test.ts
@@ -1,11 +1,11 @@
 import { IpcMain, IpcMainEvent } from 'electron';
 import mockOf from '../../test/mockOf';
-import promisifiedExec from '../utils/promisifiedExec';
+import exec from '../utils/exec';
 import register, { channel } from './sync-usb-drive';
 
-const promisifiedExecMock = mockOf(promisifiedExec);
+const execMock = mockOf(exec);
 
-jest.mock('../utils/promisifiedExec');
+jest.mock('../utils/exec');
 
 test('sync-usb-drive', async () => {
   // Register our handler.
@@ -22,5 +22,5 @@ test('sync-usb-drive', async () => {
   const [, handler] = handle.mock.calls[0];
   await handler({} as IpcMainEvent, '/media/vx/drive');
 
-  expect(promisifiedExecMock).toHaveBeenCalledWith('sync -f /media/vx/drive');
+  expect(execMock).toHaveBeenCalledWith('sync', ['-f', '/media/vx/drive']);
 });

--- a/src/ipc/sync-usb-drive.ts
+++ b/src/ipc/sync-usb-drive.ts
@@ -1,10 +1,10 @@
 import { IpcMain, IpcMainInvokeEvent } from 'electron';
-import promisifiedExec from '../utils/promisifiedExec';
+import exec from '../utils/exec';
 
 export const channel = 'syncUsbDrive';
 
 async function syncUsbDrive(mountPoint: string): Promise<void> {
-  await promisifiedExec(`sync -f ${mountPoint}`);
+  await exec('sync', ['-f', mountPoint]);
 }
 
 export default function register(ipcMain: IpcMain): void {

--- a/src/ipc/totp-get.test.ts
+++ b/src/ipc/totp-get.test.ts
@@ -8,14 +8,14 @@ jest.mock('../utils/exec');
 
 beforeEach(() => {
   execMock.mockReset();
-  execMock.mockReturnValue({ stdout: '', stderr: '' });
+  execMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
 const { ipcMain, ipcRenderer } = fakeIpc();
 register(ipcMain);
 
 test('call to totp calls appropriate shell command and returns the right data', async () => {
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '2021-09-10 14:35:02: 932549',
     stderr: '',
   });
@@ -38,7 +38,7 @@ test('call to totp calls appropriate shell command and returns the right data', 
 });
 
 test('when error in exec, return undefined', async () => {
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: 'TPM is nowhere to be found',
   });

--- a/src/ipc/totp-get.ts
+++ b/src/ipc/totp-get.ts
@@ -11,9 +11,9 @@ export interface TotpInfo {
   code: string;
 }
 
-function totpGet(): TotpInfo | undefined {
+async function totpGet(): Promise<TotpInfo | undefined> {
   try {
-    const { stdout, stderr } = exec('sudo', [
+    const { stdout, stderr } = await exec('sudo', [
       '-n',
       '/usr/local/bin/tpm2-totp',
       '-t',
@@ -35,5 +35,5 @@ function totpGet(): TotpInfo | undefined {
 }
 
 export default function register(ipcMain: IpcMain): void {
-  ipcMain.handle(channel, () => totpGet());
+  ipcMain.handle(channel, async () => totpGet());
 }

--- a/src/ipc/unmount-usb-drive.test.ts
+++ b/src/ipc/unmount-usb-drive.test.ts
@@ -18,7 +18,7 @@ test('mount-usb-drive', async () => {
   // Things should be registered as expected.
   expect(handle).toHaveBeenCalledWith(channel, expect.any(Function));
 
-  execMock.mockReturnValueOnce({
+  execMock.mockResolvedValueOnce({
     stdout: '',
     stderr: '',
   });

--- a/src/ipc/unmount-usb-drive.ts
+++ b/src/ipc/unmount-usb-drive.ts
@@ -4,12 +4,12 @@ import exec from '../utils/exec';
 
 export const channel = 'unmountUsbDrive';
 
-function unmountUsbDrive(device: string): void {
-  exec('pumount', [join('/dev', device)]);
+async function unmountUsbDrive(device: string): Promise<void> {
+  await exec('pumount', [join('/dev', device)]);
 }
 
 export default function register(ipcMain: IpcMain): void {
-  ipcMain.handle(channel, (event: IpcMainInvokeEvent, device: string) => {
-    unmountUsbDrive(device);
+  ipcMain.handle(channel, async (event: IpcMainInvokeEvent, device: string) => {
+    await unmountUsbDrive(device);
   });
 }

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -59,7 +59,7 @@ test('command with no args', async () => {
 
   // Start and finish child process.
   const execPromise = exec('ls');
-  child.emit('exit', 0, null);
+  child.emit('close', 0, null);
 
   // Check the results.
   expect(await execPromise).toEqual({ stdout: '', stderr: '' });
@@ -73,7 +73,7 @@ test('command with args', async () => {
 
   // Start and finish child process.
   const execPromise = exec('ls', ['-la']);
-  child.emit('exit', 0, null);
+  child.emit('close', 0, null);
 
   // Check the results.
   expect(await execPromise).toEqual({ stdout: '', stderr: '' });
@@ -88,7 +88,7 @@ test('command printing stdout', async () => {
   // Start and finish child process.
   const execPromise = exec('ls', ['-la']);
   await child.endStdout('README.md\n');
-  child.emit('exit', 0, null);
+  child.emit('close', 0, null);
 
   // Check the results.
   expect(await execPromise).toEqual({ stdout: 'README.md\n', stderr: '' });
@@ -103,7 +103,7 @@ test('failed command printing stderr', async () => {
   // Start and finish child process.
   const execPromise = exec('ls', ['-x']);
   await child.endStderr('unknown option "-x"');
-  child.emit('exit', 1, null);
+  child.emit('close', 1, null);
 
   // Check the results.
   await expect(execPromise).rejects.toThrowError(
@@ -123,7 +123,7 @@ test('failed command printing stderr', async () => {
   // Start and finish child process.
   const execPromise = exec('ls', ['-x']);
   await child.endStderr('unknown option "-x"');
-  child.emit('exit', 1, null);
+  child.emit('close', 1, null);
 
   // Check the results.
   await expect(execPromise).rejects.toThrowError(
@@ -145,7 +145,7 @@ test('command with stdin', async () => {
 
   // Start and finish child process.
   const execPromise = exec('lpr', ['-P', 'VxPrinter'], 'foobarbaz to print');
-  child.emit('exit', 0, null);
+  child.emit('close', 0, null);
   await execPromise;
 
   // Check the results.

--- a/src/utils/exec.test.ts
+++ b/src/utils/exec.test.ts
@@ -1,66 +1,154 @@
-import { spawnSync, SpawnSyncReturns } from 'child_process';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 import exec from './exec';
 import mockOf from '../../test/mockOf';
+import { EventEmitter } from 'events';
+import MemoryStream from 'memorystream';
 
 jest.mock('child_process');
 
-function mockSpawnSync(results: Partial<SpawnSyncReturns<string>> = {}): void {
-  const stdout = results.stdout || '';
-  const stderr = results.stderr || '';
-  mockOf(spawnSync).mockReturnValueOnce({
-    pid: 1,
-    status: 0,
-    signal: 'SIGTERM',
-    stdout,
-    stderr,
-    output: [stdout, stderr],
-    ...results,
+type FakeChildProcess = ChildProcessWithoutNullStreams & {
+  endStdout(data?: string | Buffer): Promise<void>;
+  endStderr(data?: string | Buffer): Promise<void>;
+};
+
+function fakeChildProcess(stdinData?: string | Buffer): FakeChildProcess {
+  const result = new EventEmitter() as FakeChildProcess;
+  const stdin = new MemoryStream(stdinData);
+  const stdout = new MemoryStream();
+  const stderr = new MemoryStream();
+
+  Object.defineProperties(result, {
+    stdin: {
+      value: stdin,
+    },
+
+    stdout: {
+      value: stdout,
+    },
+
+    stderr: {
+      value: stderr,
+    },
+
+    endStdout: {
+      value: async (data?: string | Buffer): Promise<void> =>
+        new Promise((resolve) => {
+          stdout.end(data, () => {
+            resolve();
+          });
+        }),
+    },
+
+    endStderr: {
+      value: async (data?: string | Buffer): Promise<void> =>
+        new Promise((resolve) => {
+          stderr.end(data, () => {
+            resolve();
+          });
+        }),
+    },
   });
+
+  return result;
 }
 
-test('command with no args', () => {
-  mockSpawnSync();
-  const execResults = exec('ls');
-  expect(execResults).toEqual({ stdout: '', stderr: '' });
-  expect(spawnSync).toHaveBeenCalledWith('ls', [], { input: undefined });
+test('command with no args', async () => {
+  // Set up child process.
+  const child = fakeChildProcess();
+  mockOf(spawn).mockReturnValueOnce(child);
+
+  // Start and finish child process.
+  const execPromise = exec('ls');
+  child.emit('exit', 0, null);
+
+  // Check the results.
+  expect(await execPromise).toEqual({ stdout: '', stderr: '' });
+  expect(spawn).toHaveBeenCalledWith('ls', []);
 });
 
-test('command with args', () => {
-  mockSpawnSync();
-  const execResults = exec('ls', ['-la']);
-  expect(execResults).toEqual({ stdout: '', stderr: '' });
-  expect(spawnSync).toHaveBeenCalledWith('ls', ['-la'], { input: undefined });
+test('command with args', async () => {
+  // Set up child process.
+  const child = fakeChildProcess();
+  mockOf(spawn).mockReturnValueOnce(child);
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-la']);
+  child.emit('exit', 0, null);
+
+  // Check the results.
+  expect(await execPromise).toEqual({ stdout: '', stderr: '' });
+  expect(spawn).toHaveBeenCalledWith('ls', ['-la']);
 });
 
-test('command printing stdout', () => {
-  mockSpawnSync({ stdout: 'README.md\n' });
-  const execResults = exec('ls', ['-la']);
-  expect(execResults).toEqual({ stdout: 'README.md\n', stderr: '' });
-  expect(spawnSync).toHaveBeenCalledWith('ls', ['-la'], { input: undefined });
+test('command printing stdout', async () => {
+  // Set up child process.
+  const child = fakeChildProcess();
+  mockOf(spawn).mockReturnValueOnce(child);
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-la']);
+  await child.endStdout('README.md\n');
+  child.emit('exit', 0, null);
+
+  // Check the results.
+  expect(await execPromise).toEqual({ stdout: 'README.md\n', stderr: '' });
+  expect(spawn).toHaveBeenCalledWith('ls', ['-la']);
 });
 
-test('failed command printing stderr', () => {
-  mockSpawnSync({ status: 1, stderr: 'unknown option "-x"' });
-  expect(() => exec('ls', ['-x'])).toThrowError(
+test('failed command printing stderr', async () => {
+  // Set up child process.
+  const child = fakeChildProcess();
+  mockOf(spawn).mockReturnValueOnce(child);
+
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-x']);
+  await child.endStderr('unknown option "-x"');
+  child.emit('exit', 1, null);
+
+  // Check the results.
+  await expect(execPromise).rejects.toThrowError(
     expect.objectContaining({
       stderr: 'unknown option "-x"',
       code: 1,
     }) as Error,
   );
-  expect(spawnSync).toHaveBeenCalledWith('ls', ['-x'], { input: undefined });
+  expect(spawn).toHaveBeenCalledWith('ls', ['-x']);
 });
 
-test('command with stdin', () => {
-  mockSpawnSync();
-  exec('lpr', ['-P', 'VxPrinter'], 'foobarbaz to print');
-  expect(spawnSync).toHaveBeenCalledWith('lpr', ['-P', 'VxPrinter'], {
-    input: 'foobarbaz to print',
-  });
-});
+test('failed command printing stderr', async () => {
+  // Set up child process.
+  const child = fakeChildProcess();
+  mockOf(spawn).mockReturnValueOnce(child);
 
-test('unknown command', () => {
-  mockSpawnSync({ error: new Error('Error: spawnSync not-a-command ENOENT') });
-  expect(() => exec('not-a-command')).toThrowError(
-    'Error: spawnSync not-a-command ENOENT',
+  // Start and finish child process.
+  const execPromise = exec('ls', ['-x']);
+  await child.endStderr('unknown option "-x"');
+  child.emit('exit', 1, null);
+
+  // Check the results.
+  await expect(execPromise).rejects.toThrowError(
+    expect.objectContaining({
+      stdout: '',
+      stderr: 'unknown option "-x"',
+      code: 1,
+    }) as Error,
   );
+  expect(spawn).toHaveBeenCalledWith('ls', ['-x']);
+});
+
+test('command with stdin', async () => {
+  // Set up child process.
+  const child = fakeChildProcess();
+  mockOf(spawn).mockReturnValueOnce(child);
+  child.stdin.write = jest.fn();
+  child.stdin.end = jest.fn();
+
+  // Start and finish child process.
+  const execPromise = exec('lpr', ['-P', 'VxPrinter'], 'foobarbaz to print');
+  child.emit('exit', 0, null);
+  await execPromise;
+
+  // Check the results.
+  expect(child.stdin.write).toHaveBeenCalledWith('foobarbaz to print');
+  expect(child.stdin.end).toHaveBeenCalled();
 });

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -38,7 +38,7 @@ export default async function exec(
   }
 
   return new Promise((resolve, reject) => {
-    child.on('exit', (code, signal) => {
+    child.on('close', (code, signal) => {
       debug(
         'process %d exited with code=%d, signal=%s (command=%s args=%o)',
         child.pid,

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -4,7 +4,10 @@ import makeDebug from 'debug';
 const debug = makeDebug('kiosk-browser:exec');
 
 /**
- * Like `child_process.exec`, but with easy stdin.
+ * The native `child_process.exec` does not sanitize input, so we have our own
+ * custom `exec` function which does sanitize input by using
+ * `child_process.spawn` under the hood. It also offers easier stdio than
+ * `child_process.exec`.
  */
 export default async function exec(
   file: string,

--- a/src/utils/printing/autoconfigurePrinter.ts
+++ b/src/utils/printing/autoconfigurePrinter.ts
@@ -11,23 +11,22 @@ export default function autoconfigurePrinter(
       list: Iterable<KioskBrowser.Device>,
     ): void {
       for (const device of list) {
-        try {
-          const configured = configurePrinterFromDevice(config, device);
-          if (configured) {
-            debug(
-              'yielding printer configure event after configuring printer: %o',
-              device,
-            );
-            subscriber.next();
-          } else {
-            debug(
-              'newly added device was not configured as a printer: %o',
-              device,
-            );
-          }
-        } catch (error) {
-          subscriber.error(error);
-        }
+        configurePrinterFromDevice(config, device)
+          .then((configured) => {
+            if (configured) {
+              debug(
+                'yielding printer configure event after configuring printer: %o',
+                device,
+              );
+              subscriber.next();
+            } else {
+              debug(
+                'newly added device was not configured as a printer: %o',
+                device,
+              );
+            }
+          })
+          .catch((error) => subscriber.error(error));
       }
     }),
   );

--- a/src/utils/printing/configurePrinter.test.ts
+++ b/src/utils/printing/configurePrinter.test.ts
@@ -4,12 +4,12 @@ import { PostScriptPrinterDefinition } from '.';
 
 jest.mock('../exec');
 
-test('configure with PPD file', () => {
+test('configure with PPD file', async () => {
   const printerName = 'Example_Printer';
   const deviceURI = 'usb://Example/Printer';
   const ppd: PostScriptPrinterDefinition = { path: '/example-printer.ppd' };
 
-  configurePrinter({ printerName, deviceURI, ppd });
+  await configurePrinter({ printerName, deviceURI, ppd });
 
   expect(exec).toHaveBeenCalledTimes(1);
   expect(exec).toHaveBeenCalledWith('lpadmin', [
@@ -23,14 +23,14 @@ test('configure with PPD file', () => {
   ]);
 });
 
-test('configure with PPD model', () => {
+test('configure with PPD model', async () => {
   const printerName = 'Example_Printer';
   const deviceURI = 'usb://Example/Printer';
   const ppd: PostScriptPrinterDefinition = {
     model: 'foomatic://example-printer.ppd',
   };
 
-  configurePrinter({ printerName, deviceURI, ppd });
+  await configurePrinter({ printerName, deviceURI, ppd });
 
   expect(exec).toHaveBeenCalledTimes(1);
   expect(exec).toHaveBeenCalledWith('lpadmin', [
@@ -44,12 +44,12 @@ test('configure with PPD model', () => {
   ]);
 });
 
-test('configure as default', () => {
+test('configure as default', async () => {
   const printerName = 'Example_Printer';
   const deviceURI = 'usb://Example/Printer';
   const ppd: PostScriptPrinterDefinition = { path: '/example-printer.ppd' };
 
-  configurePrinter({ printerName, deviceURI, ppd, setDefault: true });
+  await configurePrinter({ printerName, deviceURI, ppd, setDefault: true });
 
   expect(exec).toHaveBeenCalledTimes(2);
   expect(exec).toHaveBeenNthCalledWith(2, 'lpadmin', ['-d', printerName]);

--- a/src/utils/printing/configurePrinter.ts
+++ b/src/utils/printing/configurePrinter.ts
@@ -5,7 +5,7 @@ import exec from '../exec';
  * Configures a printer at a given device URI with a name and PPD. Optionally
  * sets the printer as the default printer too.
  */
-export default function configurePrinter({
+export default async function configurePrinter({
   printerName,
   deviceURI,
   ppd,
@@ -15,7 +15,7 @@ export default function configurePrinter({
   deviceURI: string;
   ppd: PostScriptPrinterDefinition;
   setDefault?: boolean;
-}): boolean | void {
+}): Promise<boolean | void> {
   const lpadminConfigureArgs = ['-p', printerName, '-v', deviceURI, '-E'];
 
   if ('path' in ppd) {
@@ -25,7 +25,7 @@ export default function configurePrinter({
   }
 
   debug('configuring printer with lpadmin: args=%o', lpadminConfigureArgs);
-  exec('lpadmin', lpadminConfigureArgs);
+  await exec('lpadmin', lpadminConfigureArgs);
 
   if (setDefault) {
     const lpadminSetDefaultArgs = ['-d', printerName];
@@ -33,6 +33,6 @@ export default function configurePrinter({
       'setting printer as default with lpadmin: args=%o',
       lpadminSetDefaultArgs,
     );
-    exec('lpadmin', lpadminSetDefaultArgs);
+    await exec('lpadmin', lpadminSetDefaultArgs);
   }
 }

--- a/src/utils/printing/configurePrinterFromDevice.test.ts
+++ b/src/utils/printing/configurePrinterFromDevice.test.ts
@@ -9,8 +9,8 @@ jest.mock('./configurePrinter');
 jest.mock('./getConnectedDeviceURIs');
 jest.mock('./getPrinterDeviceURI');
 
-test('device not matching a known printer', () => {
-  configurePrinterFromDevice(
+test('device not matching a known printer', async () => {
+  await configurePrinterFromDevice(
     {
       printerName: 'VxPrinter',
       printers: [],
@@ -21,10 +21,10 @@ test('device not matching a known printer', () => {
   expect(configurePrinter).not.toHaveBeenCalled();
 });
 
-test('device matching a known printer but not matching a connected device URI', () => {
-  mockOf(getConnectedDeviceURIs).mockReturnValueOnce(new Set());
+test('device matching a known printer but not matching a connected device URI', async () => {
+  mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(new Set());
 
-  configurePrinterFromDevice(
+  await configurePrinterFromDevice(
     {
       printerName: 'VxPrinter',
       printers: [
@@ -43,12 +43,12 @@ test('device matching a known printer but not matching a connected device URI', 
   expect(configurePrinter).not.toHaveBeenCalled();
 });
 
-test('device matching a known printer and a connected device URI', () => {
-  mockOf(getConnectedDeviceURIs).mockReturnValueOnce(
+test('device matching a known printer and a connected device URI', async () => {
+  mockOf(getConnectedDeviceURIs).mockResolvedValueOnce(
     new Set(['usb://HP/LaserSomething?serial=abc123']),
   );
 
-  configurePrinterFromDevice(
+  await configurePrinterFromDevice(
     {
       printerName: 'VxPrinter',
       printers: [

--- a/src/utils/printing/configurePrinterFromDevice.ts
+++ b/src/utils/printing/configurePrinterFromDevice.ts
@@ -5,10 +5,10 @@ import getConnectedDeviceURIs from './getConnectedDeviceURIs';
 import getPrinterDeviceURI from './getPrinterDeviceURI';
 import { debug, PrintConfig } from '.';
 
-export default function configurePrinterFromDevice(
+export default async function configurePrinterFromDevice(
   config: PrintConfig,
   device: KioskBrowser.Device,
-): boolean {
+): Promise<boolean> {
   const printer = getPrinterConfigForDevice(config, device);
 
   if (!printer) {
@@ -16,7 +16,7 @@ export default function configurePrinterFromDevice(
     return false;
   }
 
-  const deviceURIs = getConnectedDeviceURIs(new Set(['usb']));
+  const deviceURIs = await getConnectedDeviceURIs(new Set(['usb']));
   const deviceURI = findDeviceURIMatchingPrinterConfig(printer, deviceURIs);
 
   if (!deviceURI) {
@@ -28,14 +28,14 @@ export default function configurePrinterFromDevice(
     return false;
   }
 
-  const namedPrinterDeviceURI = getPrinterDeviceURI(config.printerName);
+  const namedPrinterDeviceURI = await getPrinterDeviceURI(config.printerName);
 
   if (namedPrinterDeviceURI === deviceURI) {
     debug('printer "%s" is already configured, skipping', config.printerName);
     return false;
   }
 
-  configurePrinter({
+  await configurePrinter({
     printerName: config.printerName,
     ppd: printer.ppd,
     deviceURI,

--- a/src/utils/printing/getConnectedDeviceURIs.test.ts
+++ b/src/utils/printing/getConnectedDeviceURIs.test.ts
@@ -7,26 +7,26 @@ jest.mock('../exec', () => jest.fn());
 const execMock = mockOf(exec);
 
 describe('getConnectedDeviceURIs', () => {
-  it('calls out to lpinfo without any schemes', () => {
-    execMock.mockReturnValue({
+  it('calls out to lpinfo without any schemes', async () => {
+    execMock.mockResolvedValue({
       stdout: 'direct usb://HP/Color%20LaserJet?serial=1234',
       stderr: '',
     });
 
-    expect(getConnectedDeviceURIs()).toEqual(
+    expect(await getConnectedDeviceURIs()).toEqual(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
 
     expect(execMock).toHaveBeenCalledWith('lpinfo', ['-v']);
   });
 
-  it('calls out to lpinfo with schemes', () => {
-    execMock.mockReturnValue({
+  it('calls out to lpinfo with schemes', async () => {
+    execMock.mockResolvedValue({
       stdout: 'direct usb://HP/Color%20LaserJet?serial=1234',
       stderr: '',
     });
 
-    expect(getConnectedDeviceURIs(new Set(['usb', 'ippusb']))).toEqual(
+    expect(await getConnectedDeviceURIs(new Set(['usb', 'ippusb']))).toEqual(
       new Set(['usb://HP/Color%20LaserJet?serial=1234']),
     );
 

--- a/src/utils/printing/getConnectedDeviceURIs.ts
+++ b/src/utils/printing/getConnectedDeviceURIs.ts
@@ -4,9 +4,9 @@ import { debug } from '.';
 /**
  * Gets the URIs of any connected printers matching the given schemes.
  */
-export default function getConnectedDeviceURIs(
+export default async function getConnectedDeviceURIs(
   schemes?: Set<string>,
-): Set<string> {
+): Promise<Set<string>> {
   const lpinfoArgs: string[] = [];
 
   if (schemes?.size) {
@@ -20,7 +20,7 @@ export default function getConnectedDeviceURIs(
   lpinfoArgs.push('-v');
 
   debug('getting connected device URIs from lpinfo, args=%o', lpinfoArgs);
-  const { stdout, stderr } = exec('lpinfo', lpinfoArgs);
+  const { stdout, stderr } = await exec('lpinfo', lpinfoArgs);
   debug('lpinfo stdout:\n%s', stdout);
   debug('lpinfo stderr:\n%s', stderr);
 

--- a/src/utils/printing/getPrinterDeviceURI.test.ts
+++ b/src/utils/printing/getPrinterDeviceURI.test.ts
@@ -6,45 +6,47 @@ jest.mock('../exec');
 
 const execMock = mockOf(exec);
 
-test('missing printer', () => {
-  execMock.mockImplementationOnce(() => {
-    throw makeExecError({
+test('missing printer', async () => {
+  execMock.mockRejectedValueOnce(
+    makeExecError({
       cmd: 'lpstat -v missing-printer',
       stderr: 'lpstat: Invalid destination name in list "missing-printer".',
-    });
-  });
+    }),
+  );
 
-  expect(getPrinterDeviceURI('missing-printer')).toBeUndefined();
+  expect(await getPrinterDeviceURI('missing-printer')).toBeUndefined();
   expect(execMock).toHaveBeenCalledWith('lpstat', ['-v', 'missing-printer']);
 });
 
-test('printer configured with valid destination', () => {
-  execMock.mockReturnValueOnce({
+test('printer configured with valid destination', async () => {
+  execMock.mockResolvedValueOnce({
     stdout: 'device for valid-printer: usb://HP/Something\n',
     stderr: '',
   });
 
-  expect(getPrinterDeviceURI('valid-printer')).toEqual('usb://HP/Something');
+  expect(await getPrinterDeviceURI('valid-printer')).toEqual(
+    'usb://HP/Something',
+  );
   expect(execMock).toHaveBeenCalledWith('lpstat', ['-v', 'valid-printer']);
 });
 
-test('different printer returned from `lpstat`', () => {
-  execMock.mockReturnValueOnce({
+test('different printer returned from `lpstat`', async () => {
+  execMock.mockResolvedValueOnce({
     stdout: 'device for another-printer: usb://HP/Something\n',
     stderr: '',
   });
 
-  expect(() => getPrinterDeviceURI('a-printer')).toThrowError(
+  await expect(getPrinterDeviceURI('a-printer')).rejects.toThrowError(
     'lpstat returned a different printer than requested: another-printer != a-printer',
   );
   expect(execMock).toHaveBeenCalledWith('lpstat', ['-v', 'a-printer']);
 });
 
-test('`lpstat` gibberish', () => {
-  execMock.mockReturnValueOnce({
+test('`lpstat` gibberish', async () => {
+  execMock.mockResolvedValueOnce({
     stdout: 'abba gazabba',
     stderr: '',
   });
 
-  expect(getPrinterDeviceURI('a-printer')).toBeUndefined();
+  expect(await getPrinterDeviceURI('a-printer')).toBeUndefined();
 });

--- a/src/utils/printing/getPrinterDeviceURI.ts
+++ b/src/utils/printing/getPrinterDeviceURI.ts
@@ -4,9 +4,9 @@ import { ok } from '../assert';
 
 const lpstatDeviceLinePattern = /^device for (.+): (.+)$/;
 
-export default function getPrinterDeviceURI(
+export default async function getPrinterDeviceURI(
   printerName: string,
-): string | undefined {
+): Promise<string | undefined> {
   const lpstatArgs = ['-v', printerName];
   debug('getting printer device URI from `lpstat` with args=%o', lpstatArgs);
 
@@ -14,7 +14,7 @@ export default function getPrinterDeviceURI(
   let stderr: string;
 
   try {
-    ({ stdout, stderr } = exec('lpstat', ['-v', printerName]));
+    ({ stdout, stderr } = await exec('lpstat', ['-v', printerName]));
   } catch (error) {
     debug('`lpstat` failed with error: %O', error);
     return undefined;

--- a/src/utils/printing/getPrinterIppAttributes.test.ts
+++ b/src/utils/printing/getPrinterIppAttributes.test.ts
@@ -8,20 +8,20 @@ jest.mock('../exec');
 const ippUri = 'ipp://localhost:60000/ipp/print';
 
 describe('getPrinterIppAttributes', () => {
-  it('uses ipptool to query and parse printer atttributes', () => {
-    mockOf(exec).mockReturnValueOnce({
+  it('uses ipptool to query and parse printer atttributes', async () => {
+    mockOf(exec).mockResolvedValueOnce({
       stdout: fakeIpptoolStdout(),
       stderr: '',
     });
-    expect(getPrinterIppAttributes(ippUri)).toEqual({
+    expect(await getPrinterIppAttributes(ippUri)).toEqual({
       state: 'idle',
       stateReasons: ['none'],
       markerInfos: [fakeMarkerInfo],
     });
   });
 
-  it('parses multiple marker infos', () => {
-    mockOf(exec).mockReturnValueOnce({
+  it('parses multiple marker infos', async () => {
+    mockOf(exec).mockResolvedValueOnce({
       stdout: fakeIpptoolStdout({
         'marker-names':
           '(1setOf nameWithoutLanguage) = black cartridge,color cartridge',
@@ -33,7 +33,7 @@ describe('getPrinterIppAttributes', () => {
       }),
       stderr: '',
     });
-    expect(getPrinterIppAttributes(ippUri)).toEqual({
+    expect(await getPrinterIppAttributes(ippUri)).toEqual({
       state: 'idle',
       stateReasons: ['none'],
       markerInfos: [
@@ -50,8 +50,8 @@ describe('getPrinterIppAttributes', () => {
     });
   });
 
-  it('parses multiple printer-state-reasons', () => {
-    mockOf(exec).mockReturnValueOnce({
+  it('parses multiple printer-state-reasons', async () => {
+    mockOf(exec).mockResolvedValueOnce({
       stdout: fakeIpptoolStdout({
         'printer-state': '(enum) = stopped',
         'printer-state-reasons':
@@ -59,7 +59,7 @@ describe('getPrinterIppAttributes', () => {
       }),
       stderr: '',
     });
-    expect(getPrinterIppAttributes(ippUri)).toEqual({
+    expect(await getPrinterIppAttributes(ippUri)).toEqual({
       state: 'stopped',
       stateReasons: [
         'media-empty-error',
@@ -70,55 +70,53 @@ describe('getPrinterIppAttributes', () => {
     });
   });
 
-  it('creates a special printer-state-reason if HP sleep mode detected', () => {
-    mockOf(exec).mockReturnValueOnce({
+  it('creates a special printer-state-reason if HP sleep mode detected', async () => {
+    mockOf(exec).mockResolvedValueOnce({
       stdout: fakeIpptoolStdout({
         'printer-alert-description':
           '(1setOf textWithoutLanguage) = ,Ready,Sleep Mode',
       }),
       stderr: '',
     });
-    expect(getPrinterIppAttributes(ippUri)).toEqual({
+    expect(await getPrinterIppAttributes(ippUri)).toEqual({
       state: 'idle',
       stateReasons: ['sleep-mode'],
       markerInfos: [fakeMarkerInfo],
     });
   });
 
-  it('throws an error if ipptool fails', () => {
-    mockOf(exec).mockImplementationOnce(() => {
-      throw new Error('ipptool failed');
-    });
-    expect(() => getPrinterIppAttributes(ippUri)).toThrow(
+  it('throws an error if ipptool fails', async () => {
+    mockOf(exec).mockRejectedValueOnce(new Error('ipptool failed'));
+    await expect(getPrinterIppAttributes(ippUri)).rejects.toThrow(
       new Error('ipptool failed'),
     );
   });
 
-  it('throws an error if ipptool output cannot be parsed', () => {
+  it('throws an error if ipptool output cannot be parsed', async () => {
     const badOutput = [
       ['', 'Unsuccessful ipptool response: '],
       [
         `"/tmp/tmp-122141-YkVU4ekfP1Eg":
-        Get-Printer-Attributes:
-            attributes-charset (charset) = utf-8
-            attributes-natural-language (naturalLanguage) = en
-            printer-uri (uri) = ipp://localhost:60000/ipp/print
-            requested-attributes (1setOf keyword) = printer-state,printer-state-reasons,marker-names,marker-colors,marker-types,marker-low-levels,marker-high-levels,marker-levels,printer-alert-description
-        /tmp/tmp-122141-YkVU4ekfP1Eg                                         [PASS]
-            RECEIVED: 395 bytes in response
-            status-code = successful-ok ((null))
-      `,
+  Get-Printer-Attributes:
+      attributes-charset (charset) = utf-8
+      attributes-natural-language (naturalLanguage) = en
+      printer-uri (uri) = ipp://localhost:60000/ipp/print
+      requested-attributes (1setOf keyword) = printer-state,printer-state-reasons,marker-names,marker-colors,marker-types,marker-low-levels,marker-high-levels,marker-levels,printer-alert-description
+  /tmp/tmp-122141-YkVU4ekfP1Eg                                         [PASS]
+      RECEIVED: 395 bytes in response
+      status-code = successful-ok ((null))
+`,
         'Unsuccessful ipptool response: status-code = successful-ok ((null))',
       ],
       [
         `"/tmp/tmp-122141-YkVU4ekfP1Eg":
-        Get-Printer-Attributes:
-            attributes-charset (charset) = utf-8
-            attributes-natural-language (naturalLanguage) = en
-            printer-uri (uri) = ipp://localhost:60000/ipp/print
-            requested-attributes (1setOf keyword) = printer-state,printer-state-reasons,marker-names,marker-colors,marker-types,marker-low-levels,marker-high-levels,marker-levels,printer-alert-description
-        /tmp/tmp-122141-YkVU4ekfP1Eg                                         [PASS]
-            RECEIVED: 395 bytes in response`,
+  Get-Printer-Attributes:
+      attributes-charset (charset) = utf-8
+      attributes-natural-language (naturalLanguage) = en
+      printer-uri (uri) = ipp://localhost:60000/ipp/print
+      requested-attributes (1setOf keyword) = printer-state,printer-state-reasons,marker-names,marker-colors,marker-types,marker-low-levels,marker-high-levels,marker-levels,printer-alert-description
+  /tmp/tmp-122141-YkVU4ekfP1Eg                                         [PASS]
+      RECEIVED: 395 bytes in response`,
         'Unsuccessful ipptool response: <empty>',
       ],
       [
@@ -156,8 +154,8 @@ describe('getPrinterIppAttributes', () => {
       ],
     ];
     for (const [stdout, expectedError] of badOutput) {
-      mockOf(exec).mockReturnValueOnce({ stdout, stderr: '' });
-      expect(() => getPrinterIppAttributes(ippUri)).toThrow(
+      mockOf(exec).mockResolvedValueOnce({ stdout, stderr: '' });
+      await expect(getPrinterIppAttributes(ippUri)).rejects.toThrow(
         new Error(expectedError),
       );
     }

--- a/src/utils/printing/options.test.ts
+++ b/src/utils/printing/options.test.ts
@@ -250,13 +250,13 @@ HPFTDigit/Fourth Digit: *0 1 2 3 4 5 6 7 8 9
   `);
 });
 
-test('options for default printer', () => {
-  execMock.mockReturnValueOnce({
+test('options for default printer', async () => {
+  execMock.mockResolvedValueOnce({
     stdout: 'Opt/Option Name: A B',
     stderr: '',
   });
 
-  expect(getPrinterOptions()).toEqual({
+  expect(await getPrinterOptions()).toEqual({
     Opt: {
       key: 'Opt',
       label: 'Option Name',
@@ -267,13 +267,13 @@ test('options for default printer', () => {
   expect(exec).toHaveBeenCalledWith('lpoptions', ['-l']);
 });
 
-test('options for named printer', () => {
-  execMock.mockReturnValueOnce({
+test('options for named printer', async () => {
+  execMock.mockResolvedValueOnce({
     stdout: 'Opt/Option Name: A B',
     stderr: '',
   });
 
-  expect(getPrinterOptions('VxPrinter')).toEqual({
+  expect(await getPrinterOptions('VxPrinter')).toEqual({
     Opt: {
       key: 'Opt',
       label: 'Option Name',

--- a/src/utils/printing/options.ts
+++ b/src/utils/printing/options.ts
@@ -53,7 +53,9 @@ export function parsePrinterOptions(lptionsOutput: string): PrinterOptionMap {
  *
  * @param deviceName the name of the printer as understood by `lpoptions`
  */
-export function getPrinterOptions(deviceName?: string): PrinterOptionMap {
+export async function getPrinterOptions(
+  deviceName?: string,
+): Promise<PrinterOptionMap> {
   const lpoptionsArgs: string[] = [];
 
   if (deviceName) {
@@ -63,7 +65,7 @@ export function getPrinterOptions(deviceName?: string): PrinterOptionMap {
   lpoptionsArgs.push('-l'); // -l == list
 
   debug('calling lpoptions with args=%o', lpoptionsArgs);
-  const { stdout, stderr } = exec('lpoptions', lpoptionsArgs);
+  const { stdout, stderr } = await exec('lpoptions', lpoptionsArgs);
   debug('lpoptions returned stdout=%s, stderr=%s', stdout, stderr);
 
   const options = parsePrinterOptions(stdout);

--- a/src/utils/promisifiedExec.ts
+++ b/src/utils/promisifiedExec.ts
@@ -1,5 +1,0 @@
-import { promisify } from 'util';
-import { exec } from 'child_process';
-
-const promisifiedExec = promisify(exec);
-export default promisifiedExec;

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,80 +1,70 @@
 import { retry, NoMoreTries, retryUntil } from './retry';
 
 describe('retry', () => {
-  it('returns the result of the action if it succeeds', () => {
-    const action = jest.fn().mockReturnValueOnce('result');
-    expect(retry(action, { tries: 2 })).toEqual('result');
+  it('returns the result of the action if it succeeds', async () => {
+    const action = jest.fn().mockResolvedValueOnce('result');
+    expect(await retry(action, { tries: 2 })).toEqual('result');
   });
 
-  it('retries the action if it fails, then returns a later successful result', () => {
+  it('retries the action if it fails, then returns a later successful result', async () => {
     const action = jest
       .fn()
-      .mockImplementationOnce(() => {
-        throw new Error('error');
-      })
-      .mockReturnValueOnce('result');
-    expect(retry(action, { tries: 2 })).toEqual('result');
+      .mockRejectedValueOnce('error')
+      .mockResolvedValueOnce('result');
+    expect(await retry(action, { tries: 2 })).toEqual('result');
   });
 
-  it('retries the action if it fails up to options.tries times, then throws the last error', () => {
+  it('retries the action if it fails up to options.tries times, then throws the last error', async () => {
     const action = jest
       .fn()
-      .mockImplementationOnce(() => {
-        throw new Error('error 1');
-      })
-      .mockImplementationOnce(() => {
-        throw new Error('error 2');
-      })
-      .mockImplementationOnce(() => {
-        throw new Error('error 3');
-      });
-    expect(() => {
-      retry(action, { tries: 3 });
-    }).toThrow('error 3');
+      .mockRejectedValueOnce(new Error('error 1'))
+      .mockRejectedValueOnce(new Error('error 2'))
+      .mockRejectedValueOnce(new Error('error 3'));
+    await expect(retry(action, { tries: 3 })).rejects.toThrow('error 3');
   });
 
-  it('requires at least 2 tries', () => {
+  it('requires at least 2 tries', async () => {
     const action = jest.fn();
-    expect(() => {
-      retry(action, { tries: 1 });
-    }).toThrow('retry requires at least 2 tries');
+    await expect(retry(action, { tries: 1 })).rejects.toThrow(
+      'retry requires at least 2 tries',
+    );
   });
 });
 
 describe('retryUntil', () => {
-  it('uses options.until to test for action success', () => {
+  it('uses options.until to test for action success', async () => {
     const action = jest
       .fn()
-      .mockReturnValueOnce('fail')
-      .mockReturnValueOnce('success');
+      .mockResolvedValueOnce('fail')
+      .mockResolvedValueOnce('success');
     expect(
-      retryUntil(action, {
+      await retryUntil(action, {
         tries: 3,
         until: (result) => result === 'success',
       }),
     ).toEqual('success');
   });
 
-  it('if options.until never passes, throws NoMoreTries', () => {
+  it('if options.until never passes, throws NoMoreTries', async () => {
     const action = jest
       .fn()
-      .mockReturnValueOnce('fail')
-      .mockReturnValueOnce('fail');
-    expect(() => {
+      .mockResolvedValueOnce('fail')
+      .mockResolvedValueOnce('fail');
+    await expect(
       retryUntil(action, {
         tries: 2,
         until: (result) => result === 'success',
-      });
-    }).toThrow(NoMoreTries);
+      }),
+    ).rejects.toThrow(NoMoreTries);
   });
 
-  it('if options.until never passes but options.returnLastResult is true, returns result of last action call', () => {
+  it('if options.until never passes but options.returnLastResult is true, returns result of last action call', async () => {
     const action = jest
       .fn()
-      .mockReturnValueOnce('fail')
-      .mockReturnValueOnce('success');
+      .mockResolvedValueOnce('fail')
+      .mockResolvedValueOnce('success');
     expect(
-      retryUntil(action, {
+      await retryUntil(action, {
         tries: 2,
         until: (result) => result === 'smashing success',
         returnLastResult: true,
@@ -82,19 +72,17 @@ describe('retryUntil', () => {
     ).toEqual('success');
   });
 
-  it('throws on any errors', () => {
-    const action = jest.fn().mockImplementation(() => {
-      throw new Error('some other error');
-    });
-    expect(() => {
-      retryUntil(action, { tries: 2, until: () => true });
-    }).toThrow('some other error');
+  it('throws on any errors', async () => {
+    const action = jest.fn().mockRejectedValue(new Error('some other error'));
+    await expect(
+      retryUntil(action, { tries: 2, until: () => true }),
+    ).rejects.toThrow('some other error');
   });
 
-  it('requires at least 2 tries', () => {
+  it('requires at least 2 tries', async () => {
     const action = jest.fn();
-    expect(() => {
-      retryUntil(action, { tries: 1, until: () => true });
-    }).toThrow('retry requires at least 2 tries');
+    await expect(
+      retryUntil(action, { tries: 1, until: () => true }),
+    ).rejects.toThrow('retry requires at least 2 tries');
   });
 });

--- a/src/utils/screen.test.ts
+++ b/src/utils/screen.test.ts
@@ -6,8 +6,8 @@ jest.mock('./exec', () => jest.fn());
 
 const execMock = mockOf(exec);
 
-test('`getMainScreen` gets screen information for the first connected screen', () => {
-  execMock.mockReturnValue({
+test('`getMainScreen` gets screen information for the first connected screen', async () => {
+  execMock.mockResolvedValue({
     stdout: `Screen 0: minimum 0 x 0, current 1314 x 760, maximum 8196 x 8196
 Virtual1 disconnected
 Virtual2 connected primary 1314x760+0+0 0mm x 0mm
@@ -22,7 +22,7 @@ Virtual6 disconnected`,
     stderr: '',
   });
 
-  expect(getMainScreen()).toMatchInlineSnapshot(`
+  expect(await getMainScreen()).toMatchInlineSnapshot(`
     Object {
       "connected": true,
       "height": 760,
@@ -54,11 +54,11 @@ Virtual6 disconnected`,
   `);
 });
 
-test('`getMainScreen` returns nothing if there are no connected screens', () => {
-  execMock.mockReturnValue({
+test('`getMainScreen` returns nothing if there are no connected screens', async () => {
+  execMock.mockResolvedValue({
     stdout: '',
     stderr: '',
   });
 
-  expect(getMainScreen()).toBeUndefined();
+  expect(await getMainScreen()).toBeUndefined();
 });

--- a/src/utils/screen.ts
+++ b/src/utils/screen.ts
@@ -4,8 +4,8 @@ import xrandrParse, { Screen } from 'xrandr-parse';
 /**
  * Gets information about the main screen.
  */
-export function getMainScreen(): Screen | undefined {
-  const { stdout } = exec('xrandr', ['--query']);
+export async function getMainScreen(): Promise<Screen | undefined> {
+  const { stdout } = await exec('xrandr', ['--query']);
   const screens = xrandrParse(
     stdout.replace(/connected primary/g, 'connected'),
   ); // xrandr-parse doesn't understand "primary"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5571,14 +5571,14 @@ throat@^6.0.1:
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
 
-tmp-promise@^3.0.2:
+tmp-promise@^3.0.2, tmp-promise@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
   integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
   dependencies:
     tmp "^0.2.0"
 
-tmp@^0.2.0, tmp@^0.2.1:
+tmp@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==


### PR DESCRIPTION
Instead of #132, which adds back an async version of our `exec`, I suggest we revisit #123. In #123 we switched `exec` from using `spawn` to `spawnSync` and made adjustments in the codebase to accommodate `exec` being synchronous.

The problem #123 sought to solve was[ `exec` returning incomplete `stdout`](https://votingworks.slack.com/archives/CEL6D3GAD/p1656625454116639). The reason that it was incomplete sometimes, I think, was because the promise resolved on the `exit` signal from the child process. https://github.com/votingworks/kiosk-browser/blob/4caada949434bbdf4cefb92560ba9a0cc439a075/src/utils/exec.ts#L41 There is a different signal, `close`, which according to the node docs:

> The 'close' event is emitted after a process has ended and the stdio streams of a child process have been closed. This is distinct from the ['exit'](https://nodejs.org/api/child_process.html#event-exit) event, since multiple processes might share the same stdio streams. The 'close' event will always emit after ['exit'](https://nodejs.org/api/child_process.html#event-exit) was already emitted, or ['error'](https://nodejs.org/api/child_process.html#event-error) if the child failed to spawn.

The `close` event waits for the I/O streams to close as well, which means `stdout` is not incomplete. I did a bit of testing -changing the one event - and was able to see the spotty USB drive detection before and not after. I think our use case is the purpose of `close`.

It is nice to find a resolution to this that involves keeping the async implementation throughout `kiosk-browser`, as it means we are not blocking the main process every time we have a child process spawned.

In this PR, I have three commits:
- Revert #123 and resolve conflicts in the following files: `sign.ts`, `prepare-boot-usb.ts`, `prepare-boot-usb.test.ts`, `reboot-to-bios.ts`, and `reboot-to-bios.test.ts`
- Switch `exec` to use the `close` event
- Remove dangerous `promisifiedExec`, use `exec` instead