### PR TITLE
get label attribute when polling USBs

### DIFF
--- a/src/ipc/get-usb-drive-info.ts
+++ b/src/ipc/get-usb-drive-info.ts
@@ -8,7 +8,7 @@ const debug = makeDebug('kiosk-browser:get-usb-drives');
 
 export const channel = 'getUsbDriveInfo';
 
-const lsblkOutputs = ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER'];
+const lsblkOutputs = ['NAME', 'MOUNTPOINT', 'FSTYPE', 'FSVER', 'LABEL'];
 
 export interface BlockDevice {
   name: string;


### PR DESCRIPTION
Forgot to add this into the `lsblk` query.