### PR TITLE
feat(speak): add ability to just cache an utterance, vs. speaking it.

### DIFF
--- a/src/ipc/speak.ts
+++ b/src/ipc/speak.ts
@@ -8,6 +8,7 @@ const debug = makeDebug('kiosk-browser:speak');
 
 export interface Options {
   volume: number;
+  cacheOnly?: boolean;
 }
 
 async function setVolume(volume: number) {
@@ -38,9 +39,24 @@ async function setVolume(volume: number) {
  * @param volume Number between 0-100
  * @returns promise representing call to `spd-say`
  */
-async function speak(text: string, { volume }: Options): Promise<void> {
+async function speak(
+  text: string,
+  { volume, cacheOnly = false }: Options,
+): Promise<void> {
   // Set the audio volume before every utterance
   await setVolume(volume);
+
+  if (cacheOnly) {
+    debug('sending text "%s" to cache the wav file...', text);
+
+    try {
+      await exec('spd-cache', ['-w', text]);
+    } catch (e) {
+      debug('failed to send message to tts cache with error %s', e);
+    }
+
+    return;
+  }
 
   debug('sending text "%s" to speech dispatcher...', text);
   try {

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -179,6 +179,7 @@ declare namespace KioskBrowser {
 
   export interface SpeakOptions {
     volume: number;
+    cacheOnly?: boolean;
   }
 
   export interface Kiosk {


### PR DESCRIPTION
assumes an `spd-cache` executable in the path that does the same thing as `spd-say` except it just caches the wav file for the next time that string is called with `spd-say`. 

This is useful for tts that is not sufficiently real-time, since all the text we speak is determined at election loading time.