### PR TITLE
Add "Show Save Dialog" Channel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import usbDetection from 'usb-detection';
 import registerSetClock from './ipc/clock';
 import registerManageDeviceSubscriptionHandler from './ipc/device-subscription';
 import registerShowOpenDialog from './ipc/show-open-dialog';
+import registerShowSaveDialog from './ipc/show-save-dialog';
 import registerFileSystemGetEntriesHandler from './ipc/file-system-get-entries';
 import registerFileSystemMakeDirectoryHandler from './ipc/file-system-make-directory';
 import registerFileSystemReadFileHandler from './ipc/file-system-read-file';
@@ -123,6 +124,7 @@ async function createWindow(): Promise<void> {
     registerUnmountUsbDriveHandler,
     registerFormatUsbDrive,
     registerShowOpenDialog,
+    registerShowSaveDialog,
     registerSyncUsbDriveHandler,
     registerStorageSetHandler,
     registerStorageGetHandler,

--- a/src/ipc/show-save-dialog.test.ts
+++ b/src/ipc/show-save-dialog.test.ts
@@ -1,0 +1,25 @@
+import * as electron from 'electron';
+import register, { channel } from './show-save-dialog';
+import { fakeIpc } from '../../test/ipc';
+import mockOf from '../../test/mockOf';
+
+jest.mock('electron', () => ({
+  dialog: {
+    showSaveDialog: jest.fn(),
+  },
+}));
+
+test('show-save-dialog', async () => {
+  mockOf(electron.dialog.showSaveDialog).mockResolvedValueOnce({
+    canceled: false,
+    filePath: '/example/path.txt',
+  });
+  const { ipcMain, ipcRenderer } = fakeIpc();
+
+  register(ipcMain);
+
+  await ipcRenderer.invoke(channel, { defaultPath: '/home/user' });
+  expect(electron.dialog.showSaveDialog).toHaveBeenCalledWith({
+    defaultPath: '/home/user',
+  });
+});

--- a/src/ipc/show-save-dialog.ts
+++ b/src/ipc/show-save-dialog.ts
@@ -1,0 +1,17 @@
+import {
+  IpcMain,
+  IpcMainInvokeEvent,
+  dialog,
+  SaveDialogOptions,
+} from 'electron';
+
+export const channel = 'show-save-dialog';
+
+export default function register(ipcMain: IpcMain): void {
+  ipcMain.handle(
+    channel,
+    async (event: IpcMainInvokeEvent, options: SaveDialogOptions) => {
+      return dialog.showSaveDialog(options);
+    },
+  );
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,11 +4,14 @@ import {
   ipcRenderer,
   OpenDialogOptions,
   OpenDialogReturnValue,
+  SaveDialogOptions,
+  SaveDialogReturnValue,
 } from 'electron';
 import { MakeDirectoryOptions } from 'fs';
 import { channel as cancelSpeakChannel } from './ipc/cancel-speak';
 import { channel as setClockChannel } from './ipc/clock';
 import { channel as showOpenDialogChannel } from './ipc/show-open-dialog';
+import { channel as showSaveDialogChannel } from './ipc/show-save-dialog';
 import {
   channel as fileSystemGetEntriesChannel,
   FileSystemEntry,
@@ -94,6 +97,16 @@ function makeKiosk(): KioskBrowser.Kiosk {
         showOpenDialogChannel,
         options,
       )) as OpenDialogReturnValue;
+    },
+
+    async showSaveDialog(
+      options?: SaveDialogOptions,
+    ): Promise<SaveDialogReturnValue> {
+      debug('forwarding `showSaveDialog` to main process');
+      return (await ipcRenderer.invoke(
+        showSaveDialogChannel,
+        options,
+      )) as SaveDialogReturnValue;
     },
 
     async getBatteryInfo(): Promise<BatteryInfo | undefined> {

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -265,6 +265,10 @@ declare namespace KioskBrowser {
       options?: import('electron').OpenDialogOptions,
     ): Promise<import('electron').OpenDialogReturnValue>;
 
+    showSaveDialog(
+      options?: import('electron').SaveDialogOptions,
+    ): Promise<import('electron').SaveDialogReturnValue>;
+
     captureScreenshot(): Promise<Buffer>;
   }
 }


### PR DESCRIPTION
We have kiosk functions to "Save As" which are intertwined with writing the file through the kiosk. This is a simpler endpoint that simply allows us to leverage the system file dialog and yield a path for saving.