### PR TITLE
build(deps): install `python3` package

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -16,7 +16,7 @@ $SUDO apt-get install -y \
   libudev-dev \
   unzip \
   git \
-  python \
+  python3 \
   cups-client \
   ruby
 


### PR DESCRIPTION
The `python` package seems to be removed from Debian 12. I believe this will work with both 11 and 12.