### PR TITLE
feat(print): allow passing raw `lpr` options

### DIFF
--- a/src/ipc/print.test.ts
+++ b/src/ipc/print.test.ts
@@ -39,7 +39,14 @@ test('registers a handler to trigger a print', async () => {
 
   expect(execMock).toHaveBeenCalledWith(
     'lpr',
-    ['-P', 'mainprinter', '-o', 'sides=two-sided-long-edge', 'InputSlot=Tray3'],
+    [
+      '-P',
+      'mainprinter',
+      '-o',
+      'sides=two-sided-long-edge',
+      '-o',
+      'InputSlot=Tray3',
+    ],
     expect.anything(),
   );
 });
@@ -210,6 +217,7 @@ test('passes through raw options', async () => {
       'main printer',
       '-o',
       'sides=two-sided-long-edge',
+      '-o',
       'fit-to-page=true',
     ],
     expect.anything(),

--- a/src/ipc/print.ts
+++ b/src/ipc/print.ts
@@ -79,9 +79,8 @@ async function printData({
   // duplex
   lprOptions.push('-o', `sides=${sides}`);
 
-  // -o already pushed, can add inputslot
   if (paperSource && availablePaperSources.includes(paperSource)) {
-    lprOptions.push('InputSlot=' + paperSource);
+    lprOptions.push('-o', 'InputSlot=' + paperSource);
   }
 
   // -o already pushed, can add options from raw
@@ -90,7 +89,7 @@ async function printData({
       key.match(/^[a-zA-Z0-9][-a-zA-Z0-9]*$/),
       'key must be dashed alphanumeric',
     );
-    lprOptions.push(`${key}=${value}`);
+    lprOptions.push('-o', `${key}=${value}`);
   }
 
   if (typeof copies !== 'undefined') {

--- a/types/kiosk-window.d.ts
+++ b/types/kiosk-window.d.ts
@@ -29,6 +29,7 @@ declare namespace KioskBrowser {
     paperSource?: string;
     copies?: number;
     sides?: PrintSides;
+    raw?: { [key: string]: string };
   }
 
   /**


### PR DESCRIPTION
To be used when printing to the iDPRT thermal label printer. I intend to add `-o media=Custom.4x6in`. I could have added `media` specifically, but I felt like it might be worth just having this escape hatch.