### PR TITLE
build: remove `--offline` flags

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -9,11 +9,11 @@ local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 "${DIR}/verify-dependencies.sh"
 
 # Build the TypeScript files.
-pnpm --offline tsc
+pnpm tsc
 
 # Get the electron cache dir
 electron_timestamp=`ls ${local_user_home_dir}/.cache/electron/`
 electron_cache="${local_user_home_dir}/.cache/electron/${electron_timestamp}"
 
 # Build .deb file.
-ELECTRON_SKIP_BINARY_DOWNLOAD=1 ELECTRON_CACHE=${electron_cache} pnpm --offline app:dist
+ELECTRON_SKIP_BINARY_DOWNLOAD=1 ELECTRON_CACHE=${electron_cache} pnpm app:dist


### PR DESCRIPTION
`pnpm` does not try to fetch packages for an unknown command. This should have been included in https://github.com/votingworks/kiosk-browser/pull/155.