### PR TITLE
chore: remove cruft from install script

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -2,13 +2,7 @@
 
 set -euo pipefail
 
-SUDO=sudo
-OS=$(lsb_release -cs)
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-if [ "$(id --user)" = 0 ]; then
-  SUDO=
-fi
 
 "${DIR}/verify-dependencies.sh"
 


### PR DESCRIPTION
We no longer directly invoke `sudo`, nor switch on OS version.