### PR TITLE
build: ensure `make` scripts always run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all: install build
 
-install:
+install: FORCE
 	./script/install-dependencies.sh
 
-build:
+build: FORCE
 	./script/build.sh
+
+FORCE:


### PR DESCRIPTION
Without this, sometimes running `make build` will just do nothing. We're not using `make` to do smart incremental builds, so just run the command please `make`.