### PR TITLE
Disallow opening a new window

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,10 @@ async function createWindow(): Promise<void> {
       preload: join(__dirname, 'preload.js'),
     },
   });
+  // Don't allow opening new windows (e.g. by middle-clicking on a link)
+  mainWindow.webContents.setWindowOpenHandler(() => {
+    return { action: 'deny' };
+  });
 
   // and load the initial page.
   void mainWindow.loadURL(options.url.href);


### PR DESCRIPTION
Middle-clicking on a link will open it in a new window. We catch that event and block it.

Before

https://github.com/votingworks/kiosk-browser/assets/530106/029adf34-6198-4a78-8886-809e9f210fc2

After

https://github.com/votingworks/kiosk-browser/assets/530106/046c1ea7-dcdf-4f43-8ea0-aa06722aaaa7

