### PR TITLE
Add back author

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "keywords": [],
   "homepage": "https://github.com/votingworks/kiosk-browser",
   "license": "GPL-3.0-only",
+  "author": {
+    "name": "VotingWorks",
+    "email": "eng@voting.works"
+  },
   "main": "build/src/index.js",
   "scripts": {
     "app:dir": "electron-builder --dir",


### PR DESCRIPTION
While building images, I hit the following error, specifically at the step that builds `kiosk-browser`:

```
  ⨯ Please specify author 'email' in the application package.json

See https://docs.npmjs.com/files/package.json#people-fields-author-contributors

It is required to set Linux .deb package maintainer. Or you can set maintainer in the custom linux options.
(see https://www.electron.build/configuration/linux).
  failedTask=build stackTrace=Error: Please specify author 'email' in the application package.json
```

Adding back an `author` object with an email seemed to do the trick. Per the error message, seems that an author is required when the `package.json` has a `build.linux` entry (the case for `kiosk-browser`, not the case for `vxsuite`).

We only recently removed this while cleaning up `package.json` files across our repos: https://github.com/votingworks/kiosk-browser/pull/167.

