### PR TITLE
fix: prevent Ctrl+M from minimizing kiosk-browser window

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, IpcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, IpcMain, globalShortcut } from 'electron';
 import { join } from 'path';
 import registerShowOpenDialog from './ipc/show-open-dialog';
 import registerQuitHandler from './ipc/quit';
@@ -108,11 +108,19 @@ async function createWindow(): Promise<void> {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
+  // Register global shortcuts to prevent problematic keyboard shortcuts
+  globalShortcut.register('Control+M', () => {
+    // Do nothing to prevent minimize behavior
+  });
+
   void createWindow();
 });
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
+  // Unregister all global shortcuts when the app is closing
+  globalShortcut.unregisterAll();
+
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
@@ -126,4 +134,9 @@ app.on('activate', () => {
   if (mainWindow === undefined) {
     void createWindow();
   }
+});
+
+// Clean up global shortcuts when the app is about to quit
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
 });


### PR DESCRIPTION
## Description

This PR fixes the issue where pressing Ctrl+M would minimize the kiosk-browser window, causing the screen to go black and requiring a reboot to recover.

## Changes

- Added `globalShortcut` import to `src/index.ts`
- Registered a global shortcut for `Ctrl+M` that does nothing, preventing the default minimize behavior
- Added proper cleanup of global shortcuts when the app quits

## Testing

The fix can be tested by:

1. Building and running the kiosk-browser
2. Pressing `Ctrl+M` - the window should remain visible instead of minimizing
3. Normal operation should be unaffected

## Issue

Closes [#6601](https://github.com/votingworks/vxsuite/issues/6601)
