### PR TITLE
Use a prebuilt version of kiosk-browser when available

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Overview
+
+<!-- Add a link to a GitHub issue here -->
+
+## Demo Video or Screenshot
+
+## Testing Plan
+
+## Checklist
+
+- [ ] Updated version in package.json

--- a/script/build.sh
+++ b/script/build.sh
@@ -6,14 +6,20 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 local_user=`logname`
 local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 
-"${DIR}/verify-dependencies.sh"
+version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
+prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
 
-# Build the TypeScript files.
-yarn --offline tsc
+curl --output-dir dist/kiosk-browser_${version}_amd64.deb -O ${prebuilt_package_url} || {
+  "${DIR}/verify-dependencies.sh"
 
-# Get the electron cache dir
-electron_timestamp=`ls ${local_user_home_dir}/.cache/electron/`
-electron_cache="${local_user_home_dir}/.cache/electron/${electron_timestamp}"
+  # Build the TypeScript files.
+  yarn --offline tsc
 
-# Build .deb file.
-ELECTRON_SKIP_BINARY_DOWNLOAD=1 ELECTRON_CACHE=${electron_cache} yarn --offline app:dist
+  # Get the electron cache dir
+  electron_timestamp=`ls ${local_user_home_dir}/.cache/electron/`
+  electron_cache="${local_user_home_dir}/.cache/electron/${electron_timestamp}"
+
+  # Build .deb file.
+  ELECTRON_SKIP_BINARY_DOWNLOAD=1 ELECTRON_CACHE=${electron_cache} yarn --offline app:dist
+
+}

--- a/script/build.sh
+++ b/script/build.sh
@@ -22,4 +22,4 @@ if [[ ! -f ${prebuilt_package_path} ]]; then
   # Build .deb file.
   ELECTRON_SKIP_BINARY_DOWNLOAD=1 ELECTRON_CACHE=${electron_cache} yarn --offline app:dist
 
-}
+fi

--- a/script/build.sh
+++ b/script/build.sh
@@ -7,9 +7,9 @@ local_user=`logname`
 local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 
 version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
-prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
+prebuilt_package_path="dist/kiosk-browser_${version}_amd64.deb"
 
-curl --output-dir dist/kiosk-browser_${version}_amd64.deb -O ${prebuilt_package_url} || {
+if [[ ! -f ${prebuilt_package_path} ]]; then
   "${DIR}/verify-dependencies.sh"
 
   # Build the TypeScript files.

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -12,4 +12,6 @@ yarn install --frozen-lockfile
 version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
 prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
 
+mkdir -p dist
+
 curl -f --output-dir dist -O ${prebuilt_package_url} || echo "Couldn't download file, will build from source"

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -10,7 +10,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 yarn install --frozen-lockfile
 
 version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
-prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
+prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser/kiosk-browser_${version}_amd64.deb"
 
 mkdir -p dist
 

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -12,4 +12,4 @@ yarn install --frozen-lockfile
 version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
 prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
 
-curl --output-dir dist -O ${prebuilt_package_url} 
+curl --output-dir dist -O ${prebuilt_package_url} || { echo "Couldn't download file, will build from source" }

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -12,4 +12,4 @@ yarn install --frozen-lockfile
 version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
 prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
 
-curl --output-dir dist/kiosk-browser_${version}_amd64.deb -O ${prebuilt_package_url} 
+curl --output-dir dist -O ${prebuilt_package_url} 

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -9,6 +9,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Install kiosk-browser dependencies.
 yarn install --frozen-lockfile
 
+version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
 prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
 
 curl --output-dir dist/kiosk-browser_${version}_amd64.deb -O ${prebuilt_package_url} 

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -8,3 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Install kiosk-browser dependencies.
 yarn install --frozen-lockfile
+
+prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
+
+curl --output-dir dist/kiosk-browser_${version}_amd64.deb -O ${prebuilt_package_url} 

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -12,4 +12,4 @@ yarn install --frozen-lockfile
 version=$( grep version package.json | cut -d':' -f2 | xargs | sed 's/,//' )
 prebuilt_package_url="https://votingworks-apt-snapshots.s3.us-west-2.amazonaws.com/kiosk-browser_${version}_amd64.deb"
 
-curl --output-dir dist -O ${prebuilt_package_url} || { echo "Couldn't download file, will build from source" }
+curl -f --output-dir dist -O ${prebuilt_package_url} || echo "Couldn't download file, will build from source"


### PR DESCRIPTION
Since kiosk-browser rarely changes, it's more efficient to build it once as a Debian package and install as needed. This PR checks for an existing package based on the version found in `package.json`. If it's found, the normal build steps are bypassed. If it's not found, the normal build steps proceed as usual. Regardless, a final package will be available in the `dist` directory for use by other build processes.