### PR TITLE
add version bump check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,46 @@ jobs:
           paths:
             - '~/.cache/yarn'
           key: yarn-packages-{{ checksum "yarn.lock" }}
+  enforce-version-bump:
+    machine:
+      image: 'ubuntu-2204:current'
+    steps:
+      - checkout
+      - run:
+          name: Install jq
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y jq
+      - run:
+          name: Fetch main
+          command: |
+            git fetch --no-tags --depth=1 origin main
+      - run:
+          name: Enforce version bump
+          command: |
+            set -euo pipefail
+
+            BASE_BRANCH="origin/main"
+
+            CURRENT_VERSION="$(jq -r '.version' package.json)"
+            BASE_VERSION="$(git show ${BASE_BRANCH}:package.json 2>/dev/null | jq -r '.version')"
+
+            echo "Base version:    ${BASE_VERSION}"
+            echo "Current version: ${CURRENT_VERSION}"
+
+            if [ "${BASE_VERSION}" = "${CURRENT_VERSION}" ]; then
+              echo "ERROR: Changes detected but package.json version was not updated. Please bump the version."
+              exit 1
+            fi
+
+            echo "Version changed; passing."
 
 workflows:
   test:
     jobs:
       - test
+      - enforce-version-bump:
+          filters:
+            branches:
+              ignore:
+                - main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiosk-browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generic kiosk-mode browser.",
   "keywords": [],
   "homepage": "https://github.com/votingworks/kiosk-browser",


### PR DESCRIPTION
## Overview

I was thinking of making an entirely separate change in `kiosk-browser` when I saw https://github.com/votingworks/vxsuite/issues/7143 and got distracted. This adds a workflow to CI which checks that a branch has a different version string than `main`. We would have to make it "required" in CI. It applies to every change, not limiting itself to files in certain directories. It does not run on `main` itself, since that would always fail. You can see an example of it failing and passing in the history of this branch.

## Checklist

- [x] Updated version in package.json
